### PR TITLE
fjern støy i loggene relatert manglende profil i altinn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
         <token-support.version>2.0.15</token-support.version>
-        <altinn-rettigheter-proxy-klient.version>2.1.3</altinn-rettigheter-proxy-klient.version>
+        <altinn-rettigheter-proxy-klient.version>2.1.4</altinn-rettigheter-proxy-klient.version>
         <sonar.projectKey>navikt_ditt-nav-arbeidsgiver-api</sonar.projectKey>
         <sonar.organization>navit</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/no/nav/arbeidsgiver/min_side/services/altinn/AltinnService.java
+++ b/src/main/java/no/nav/arbeidsgiver/min_side/services/altinn/AltinnService.java
@@ -70,13 +70,13 @@ public class AltinnService {
         try {
             return fn.get();
         } catch (AltinnException exception) {
-            if (exception.getProxyError().getHttpStatus() == 403) {
+            if (exception.getProxyError().getMelding().contains("User profile could not be found")) {
                 throw new TilgangskontrollException("bruker har ikke en aktiv altinn profil", exception);
             } else {
                 throw exception;
             }
         } catch (Exception exception) {
-            if (exception.getMessage().contains("403")) {
+            if (exception.getMessage().contains("User profile could not be found")) {
                 throw new TilgangskontrollException("bruker har ikke en aktiv altinn profil", exception);
             } else {
                 throw exception;


### PR DESCRIPTION
altinn har endret oppførsel rundt dette.
før returnerte de 403 status, nå er det 400 med en custom statustext. Litt brittle integrasjon her, men #thisisfine

rel:
- https://github.com/navikt/altinn-rettigheter-proxy/pull/122
- https://github.com/navikt/altinn-rettigheter-proxy-klient/pull/44