### PR TITLE
log info i stedet for warn når retry pga bad gateway

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClient.java
+++ b/src/main/java/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClient.java
@@ -64,7 +64,7 @@ public class AltinnTilgangssøknadClient {
             try {
                 response = restTemplate.exchange(request, new ParameterizedTypeReference<>() {});
             } catch (HttpServerErrorException.BadGateway e) {
-                log.warn("retry pga bad gateway mot altinn {}", e.getMessage());
+                log.info("retry pga bad gateway mot altinn {}", e.getMessage());
                 response = restTemplate.exchange(request, new ParameterizedTypeReference<>() {});
             }
 


### PR DESCRIPTION
dette skjer regelmessig og er ganske vanlig at altinn svarer med 502. 
Er ikke noe vi kan gjøre noe med, så ser ikke helt poenget med warn her. Reduseres til info.