### PR TITLE
endre AuthenticatedUserHolder.getToken til å returnere null dersom un…

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/min_side/controller/AuthenticatedUserHolder.java
+++ b/src/main/java/no/nav/arbeidsgiver/min_side/controller/AuthenticatedUserHolder.java
@@ -21,7 +21,8 @@ public class AuthenticatedUserHolder {
     }
 
     public String getToken() {
-        return getJwtToken().getTokenAsString();
+        JwtToken jwtToken = getJwtToken();
+        return jwtToken != null ? jwtToken.getTokenAsString() : null;
     }
 
     private JwtToken getJwtToken() {


### PR DESCRIPTION
…derliggende token er null

 Dette fjerner nullpointerexception når feature toggles hentes uten inlogget context

apiet er unprotected, og kan sånn sett ikke garantere at det er en inlogget context å hente token fra.