### PR TITLE
endre logikk for visning av navn etter dialog med team-arbeidsforhold

### DIFF
--- a/src/test/groovy/no/nav/arbeidsgiver/min_side/services/ereg/EregServiceTest.groovy
+++ b/src/test/groovy/no/nav/arbeidsgiver/min_side/services/ereg/EregServiceTest.groovy
@@ -48,7 +48,7 @@ class EregServiceTest extends Specification {
 
         then:
         result.organizationNumber == "910825526"
-        result.name == "GAMLE FREDRIKSTAD OG RAMNES REGNSKA"
+        result.name == "GAMLE FREDRIKSTAD OG RAMNES REGNSKA P"
         result.parentOrganizationNumber == "810825472"
         result.organizationForm == "BEDR"
         result.type == "Business"
@@ -68,7 +68,7 @@ class EregServiceTest extends Specification {
 
         then:
         result.organizationNumber == "912998827"
-        result.name == "ARBEIDS- OG VELFERDSDIREKTORATET"
+        result.name == "ARBEIDS- OG VELFERDSDIREKTORATET AVD FYRSTIKKALLÉEN"
         result.parentOrganizationNumber == "889640782"
         result.organizationForm == "BEDR"
         result.type == "Business"


### PR DESCRIPTION
redigertnavn skal ikke brukes, men man skal joine navnelinje1-5 med mellomrom. I noen tilfeller blir detet "feil", dvs det dukker opp mellomrom midt i et navn, men det må vi leve med i følge diskusjonen.

se diskusjon i tråd https://nav-it.slack.com/archives/CAY78MSH5/p1660899165338429