### PR TITLE
Fjern ubrukt REST-endepunkt

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/min_side/controller/DigisyfoController.java
+++ b/src/main/java/no/nav/arbeidsgiver/min_side/controller/DigisyfoController.java
@@ -44,14 +44,6 @@ public class DigisyfoController {
         this.tokenUtils = authenticatedUserHolder;
     }
 
-    @GetMapping(value = "/api/narmesteleder/virksomheter")
-    public List<Organisasjon> hentVirksomheter() {
-        return nærmestelederRepository.virksomheterSomNærmesteLeder(tokenUtils.getFnr()).stream()
-                .flatMap(this::hentUnderenhetOgOverenhet)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-    }
-
     @AllArgsConstructor
     @Data
     static class DigisyfoOrganisasjon {

--- a/src/test/java/no/nav/arbeidsgiver/min_side/controller/TilgangsstyringUtføresTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/min_side/controller/TilgangsstyringUtføresTest.java
@@ -29,7 +29,7 @@ public class TilgangsstyringUtføresTest {
     public void tilgangsstyringUtføres() {
         try {
             this.mockMvc
-                    .perform(get("/api/narmesteleder/virksomheter"))
+                    .perform(get("/api/narmesteleder/virksomheter-v2"))
                     .andExpect(status().isUnauthorized());
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Endepunktet /api/narmesteleder/virksomheter-v2 har overtatt
for /api/narmesteleder/virksomheter


Se 
```
sum(increase(http_server_requests_seconds_count{app="min-side-arbeidsgiver-api",uri="/api/narmesteleder/virksomheter"}[10m]))
```
i grafana for bruk av gamelt api.
