### PR TITLE
Gjør altinn kall mer robust ved ssl feil

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClient.java
+++ b/src/main/java/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClient.java
@@ -17,6 +17,7 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import javax.net.ssl.SSLHandshakeException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,9 @@ public class AltinnTilgangssøknadClient {
             RestTemplateBuilder restTemplateBuilder,
             AltinnConfig altinnConfig
     ) {
-        this.restTemplate = restTemplateBuilder.build();
+        restTemplate = restTemplateBuilder
+                .additionalInterceptors(new RetryInterceptor(3, 250L, SSLHandshakeException.class))
+                .build();
 
         delegationRequestApiPath = UriComponentsBuilder
                 .fromUriString(altinnConfig.getProxyFallbackUrl())

--- a/src/main/java/no/nav/arbeidsgiver/min_side/clients/altinn/RetryInterceptor.java
+++ b/src/main/java/no/nav/arbeidsgiver/min_side/clients/altinn/RetryInterceptor.java
@@ -1,0 +1,35 @@
+package no.nav.arbeidsgiver.min_side.clients.altinn;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.retry.support.RetryTemplate;
+
+import java.io.IOException;
+import java.util.List;
+
+class RetryInterceptor implements ClientHttpRequestInterceptor {
+    private final RetryTemplate retryTemplate;
+
+    @SafeVarargs
+    public RetryInterceptor(int maxAttempts, long backoffPeriod, Class<? extends Throwable>... retryable) {
+        retryTemplate = RetryTemplate.builder()
+                .retryOn(List.of(retryable))
+                .traversingCauses()
+                .maxAttempts(maxAttempts)
+                .fixedBackoff(backoffPeriod)
+                .build();
+    }
+
+    @NotNull
+    @Override
+    public ClientHttpResponse intercept(
+            @NotNull HttpRequest request,
+            @NotNull byte[] body,
+            @NotNull ClientHttpRequestExecution execution
+    ) throws IOException {
+        return retryTemplate.execute(_ctx -> execution.execute(request, body));
+    }
+}


### PR DESCRIPTION
Vi ser samme problem i min-side-arbeidsgiver-api som vi så i altinn-rettigheter-proxy:
* https://github.com/navikt/altinn-rettigheter-proxy/pull/126

En del kall mot altinn feiler pga problem med ssl handshake. Dette vil som regel løses ved en rask retry.