### PR TITLE
fiks warning i prod

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  max-http-header-size: 10000
   servlet:
     context-path: /ditt-nav-arbeidsgiver-api
 


### PR DESCRIPTION
registrerer noen warnings med "Header is too large 8193>8192" i prod. Først observert 2022-11-07.