### PR TITLE
Revert "legg til warn logg med litt detaljer når vi får bad request fra altinn"

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClient.kt
@@ -14,7 +14,6 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.RequestEntity
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
-import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.HttpServerErrorException.BadGateway
 import org.springframework.web.util.UriComponentsBuilder
 import java.util.function.Consumer
@@ -106,12 +105,7 @@ class AltinnTilgangssøknadClient(
             .post("$delegationRequestApiPath?ForceEIAuthentication")
             .headers(altinnHeaders)
             .body(delegationRequest)
-        val response = try {
-            restTemplate.exchange(request, object : ParameterizedTypeReference<DelegationRequest?>() {})
-        } catch (e: HttpClientErrorException.BadRequest) {
-            log.warn("sendSøknad feilet for delegationRequest.RequestResources={}. e={}", delegationRequest.RequestResources, e.message)
-            throw e
-        }
+        val response = restTemplate.exchange(request, object : ParameterizedTypeReference<DelegationRequest?>() {})
         val body = response.body
         val svar = AltinnTilgangssøknad()
         svar.status = body!!.RequestStatus


### PR DESCRIPTION
Reverts navikt/min-side-arbeidsgiver-api#292

Trenger ikke denne loggingen lenger. fikk bekreftet at vi kun sender en tjeneste på requestene som feiler:

```
sendSøknad feilet for delegationRequest.RequestResources=[RequestResource(ServiceCode=5278, ServiceEditionCode=1)]. e=400 Bad Request: "[{"ErrorCode":"40327","ErrorMessage":"The following requested resources occur more than once on the request: 5278_1"}]"
```