### PR TITLE
fiks dobbelt opp med felter i DTO mot altinn

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/clients/altinn/dto/DelegationRequest.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/clients/altinn/dto/DelegationRequest.kt
@@ -1,25 +1,27 @@
 package no.nav.arbeidsgiver.min_side.clients.altinn.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class DelegationRequest(
-    @field:JsonProperty("RequestStatus") var RequestStatus: String? = null,
-    @field:JsonProperty("OfferedBy") var OfferedBy: String? = null,
-    @field:JsonProperty("CoveredBy") var CoveredBy: String? = null,
-    @field:JsonProperty("RedirectUrl") var RedirectUrl: String? = null,
-    @field:JsonProperty("Created") var Created: String? = null,
-    @field:JsonProperty("LastChanged") var LastChanged: String? = null,
-    @field:JsonProperty("KeepSessionAlive") val KeepSessionAlive: Boolean = true,
-    @field:JsonProperty("RequestResources") var RequestResources: List<RequestResource>? = null,
+    var RequestStatus: String? = null,
+    var OfferedBy: String? = null,
+    var CoveredBy: String? = null,
+    var RedirectUrl: String? = null,
+    var Created: String? = null,
+    var LastChanged: String? = null,
+    val KeepSessionAlive: Boolean = true,
+    var RequestResources: List<RequestResource>? = null,
     @field:JsonProperty("_links") var links: Links? = null
 ) {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class RequestResource(
-        @field:JsonProperty("ServiceCode") var ServiceCode: String? = null,
-        @field:JsonProperty("ServiceEditionCode") var ServiceEditionCode: Int? = null
+        var ServiceCode: String? = null,
+        var ServiceEditionCode: Int? = null
     )
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClientTest.kt
@@ -57,7 +57,7 @@ class AltinnTilgangssøknadClientTest {
 
         server.expect(requestToUriTemplate("http://localhost:8081/altinn/ekstern/altinn/api/serviceowner/delegationRequests?ForceEIAuthentication"))
             .andExpect(method(HttpMethod.POST))
-            .andExpect(content().json(altinnSendSøknadRequest))
+            .andExpect(content().json(altinnSendSøknadRequest, true))
             .andRespond(withSuccess(altinnSendSøknadResponse, MediaType.APPLICATION_JSON))
 
         val result = client.sendSøknad(fnr, skjema)


### PR DESCRIPTION
# Fikser `[{"ErrorCode":"40318","ErrorMessage":"This request for access has already been registered"}]`
Omskriving til kotlin endte opp med dobbelt opp med felter pga felt annotasjon og data class. Dette ble ikke fanget opp av testen, da det er akseptert som match med strict disabled, som mer default i ContentRequestMatcher.

Etter omskriving ble faktisk payload seende slik ut: 
```
{
  "RequestStatus": null,
  "OfferedBy": "314",
  "CoveredBy": "42",
  "RedirectUrl": "https://yolo.com",
  "Created": null,
  "LastChanged": null,
  "KeepSessionAlive": true,
  "RequestResources": [
    {
      "ServiceCode": "1337",
      "ServiceEditionCode": 7,
      "serviceCode": "1337",
      "serviceEditionCode": 7
    }
  ],
  "_links": null,
  "created": null,
  "redirectUrl": "https://yolo.com",
  "offeredBy": "314",
  "requestStatus": null,
  "lastChanged": null,
  "requestResources": [
    {
      "ServiceCode": "1337",
      "ServiceEditionCode": 7,
      "serviceCode": "1337",
      "serviceEditionCode": 7
    }
  ],
  "coveredBy": "42",
  "keepSessionAlive": true
}
```

# Post Mortem

[6. Januar kl 19:40](https://nav-it.slack.com/archives/GULF6A7KL/p1673030410217089) oppdaget vi at det var en del error i msa-api loggen. Etter nærmere undersøkelse så vi at det var en feil som først ble observert [3 Jan rundt i 17 tiden](https://prometheus.prod-gcp.nais.io/graph?g0.expr=max(http_client_requests_seconds_count%7Bapp%3D%22min-side-arbeidsgiver-api%22%2Curi%3D~%22.*%2Fekstern%2Faltinn%2Fapi%2Fserviceowner%2FdelegationRequests.*%22%2Cmethod%3D%22POST%22%7D)%20by%20(status)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=2w). Ikke så lenge før dette ble det [deployet en versjon ](https://github.com/navikt/min-side-arbeidsgiver-api/actions/runs/3830690169/jobs/6519021376)av appen der alt var [omskrevet til kotlin](https://github.com/navikt/min-side-arbeidsgiver-api/pull/289). Man ser i prometheus at alle post kall etter merge feilet med 400:
![image](https://user-images.githubusercontent.com/189395/211536390-9d54941a-1827-491c-8a49-26825cc62406.png)


Testene vi hadde laget [assertet at payload](https://github.com/navikt/min-side-arbeidsgiver-api/commit/102b309cc87fd68a4196a9237ec1b5efd9c79522#diff-bed64c95e5ce84beb55b96d316fb28f0ec24cda805fb3858524d4491b47892e5R58-R61) var iht [kontrakt angitt av altinn](https://www.altinn.no/api/serviceowner/Help/Api/POST-serviceowner-delegationRequests)
Denne testen fanget ikke opp at vi sendte feltene dobbelt opp med stor og liten forbokstav. Dette gjorde at vi fikk feilmeldingen `[{"ErrorCode":"40318","ErrorMessage":"This request for access has already been registered"}]`