### PR TITLE
log warn fra tomcat.util

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,9 @@ management:
     percentiles:
       http.server.requests: 0.99,0.95,0.90,0.80,0.50
 
+logging.level:
+    org.apache.tomcat.util.http.parser.Cookie: WARN
+
 spring:
   main:
     banner-mode: "off"


### PR DESCRIPTION
Ble oppmerksom på at vi fortsatt logger ugyldig cookies som info.
Min [tidligere konklusjon](https://github.com/navikt/min-side-arbeidsgiver-api/commit/43bf967b212cb9cc8e320c8a52b343bcc17eb42e) var altså feil.
Skrur om til WARN for å hindre at slike info meldinger blir logget.

ref tråd på slack: https://nav-it.slack.com/archives/C03V509RQKB/p1675075571921459