### PR TITLE
Support both old and new claim for idporten "nivå 4"

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/AltinnTilgangController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/AltinnTilgangController.kt
@@ -2,6 +2,9 @@ package no.nav.arbeidsgiver.min_side.controller
 
 import no.nav.arbeidsgiver.min_side.clients.altinn.AltinnTilgangssøknadClient
 import no.nav.arbeidsgiver.min_side.config.logger
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_NEW
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_OLD
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.TOKENX
 import no.nav.arbeidsgiver.min_side.models.AltinnTilgangssøknad
 import no.nav.arbeidsgiver.min_side.models.AltinnTilgangssøknadsskjema
 import no.nav.arbeidsgiver.min_side.services.altinn.AltinnService
@@ -11,8 +14,9 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @ProtectedWithClaims(
-    issuer = AuthenticatedUserHolder.TOKENX,
-    claimMap = [AuthenticatedUserHolder.REQUIRED_LOGIN_LEVEL]
+    issuer = TOKENX,
+    claimMap = [ACR_CLAIM_OLD, ACR_CLAIM_NEW],
+    combineWithOr = true,
 )
 @RestController
 @RequestMapping("/api/altinn-tilgangssoknad")

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/AuthenticatedUserHolder.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/AuthenticatedUserHolder.kt
@@ -22,6 +22,7 @@ class AuthenticatedUserHolder(private val requestContextHolder: TokenValidationC
 
     companion object {
         const val TOKENX = "tokenx"
-        const val REQUIRED_LOGIN_LEVEL = "acr=Level4"
+        const val ACR_CLAIM_OLD = "acr=Level4"
+        const val ACR_CLAIM_NEW = "acr=idporten-loa-high"
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/DigisyfoController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/DigisyfoController.kt
@@ -1,5 +1,8 @@
 package no.nav.arbeidsgiver.min_side.controller
 
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_NEW
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_OLD
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.TOKENX
 import no.nav.arbeidsgiver.min_side.models.Organisasjon
 import no.nav.arbeidsgiver.min_side.services.digisyfo.DigisyfoService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -7,8 +10,9 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(
-    issuer = AuthenticatedUserHolder.TOKENX,
-    claimMap = [AuthenticatedUserHolder.REQUIRED_LOGIN_LEVEL]
+    issuer = TOKENX,
+    claimMap = [ACR_CLAIM_OLD, ACR_CLAIM_NEW],
+    combineWithOr = true,
 )
 @RestController
 class DigisyfoController(

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/InnloggingsController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/InnloggingsController.kt
@@ -1,12 +1,19 @@
 package no.nav.arbeidsgiver.min_side.controller
 
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_NEW
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_OLD
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.TOKENX
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.CacheControl
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
-@ProtectedWithClaims(issuer = AuthenticatedUserHolder.TOKENX, claimMap = [AuthenticatedUserHolder.REQUIRED_LOGIN_LEVEL])
+@ProtectedWithClaims(
+    issuer = TOKENX,
+    claimMap = [ACR_CLAIM_OLD, ACR_CLAIM_NEW],
+    combineWithOr = true,
+)
 @RestController
 class InnloggingsController {
     @GetMapping("/api/innlogget")

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/OrganisasjonController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/OrganisasjonController.kt
@@ -1,5 +1,8 @@
 package no.nav.arbeidsgiver.min_side.controller
 
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_NEW
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_OLD
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.TOKENX
 import no.nav.arbeidsgiver.min_side.services.altinn.AltinnService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.GetMapping
@@ -7,8 +10,9 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @ProtectedWithClaims(
-    issuer = AuthenticatedUserHolder.TOKENX,
-    claimMap = [AuthenticatedUserHolder.REQUIRED_LOGIN_LEVEL]
+    issuer = TOKENX,
+    claimMap = [ACR_CLAIM_OLD, ACR_CLAIM_NEW],
+    combineWithOr = true,
 )
 @RestController
 class OrganisasjonController(

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/RefusjonStatusController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/RefusjonStatusController.kt
@@ -1,5 +1,8 @@
 package no.nav.arbeidsgiver.min_side.controller
 
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_NEW
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_OLD
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.TOKENX
 import no.nav.arbeidsgiver.min_side.models.Organisasjon
 import no.nav.arbeidsgiver.min_side.services.altinn.AltinnService
 import no.nav.arbeidsgiver.min_side.services.tiltak.RefusjonStatusRepository
@@ -12,8 +15,9 @@ private const val TJENESTEKODE = "4936"
 private const val TJENESTEVERSJON = "1"
 
 @ProtectedWithClaims(
-    issuer = AuthenticatedUserHolder.TOKENX,
-    claimMap = [AuthenticatedUserHolder.REQUIRED_LOGIN_LEVEL]
+    issuer = TOKENX,
+    claimMap = [ACR_CLAIM_OLD, ACR_CLAIM_NEW],
+    combineWithOr = true,
 )
 @RestController
 class RefusjonStatusController(

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/StorageController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/controller/StorageController.kt
@@ -1,5 +1,8 @@
 package no.nav.arbeidsgiver.min_side.controller
 
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_NEW
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.ACR_CLAIM_OLD
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder.Companion.TOKENX
 import no.nav.arbeidsgiver.min_side.services.storage.StaleStorageException
 import no.nav.arbeidsgiver.min_side.services.storage.StorageEntry
 import no.nav.arbeidsgiver.min_side.services.storage.StorageService
@@ -10,8 +13,9 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @ProtectedWithClaims(
-    issuer = AuthenticatedUserHolder.TOKENX,
-    claimMap = [AuthenticatedUserHolder.REQUIRED_LOGIN_LEVEL]
+    issuer = TOKENX,
+    claimMap = [ACR_CLAIM_OLD, ACR_CLAIM_NEW],
+    combineWithOr = true,
 )
 @RestController
 class StorageController(


### PR DESCRIPTION
ID-porten endrer acr-claimet. I en periode burde både ny og gammel verdi av acr-claimet støttes.

https://nav-it.slack.com/archives/C01DE3M9YBV/p1686121200932109

Testet i dev.