### PR TITLE
Injekt mer spesifikke claims-checks

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/SecurityConfiguration.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/SecurityConfiguration.kt
@@ -1,21 +1,26 @@
 package no.nav.arbeidsgiver.min_side
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
-import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
+import org.springframework.security.oauth2.core.OAuth2TokenValidator
 import org.springframework.security.oauth2.jwt.*
 import org.springframework.security.oauth2.jwt.JwtClaimNames.AUD
+import org.springframework.security.oauth2.jwt.JwtClaimValidator
 import org.springframework.security.web.SecurityFilterChain
 
 
+// https://doc.nais.io/security/auth/concepts/tokens/#token-validation
 // https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html
 @Configuration
 @EnableWebSecurity
-class SecurityConfiguration {
+class SecurityConfiguration(
+    @Value("\${idporten.client.id}") private val idportenClientId: String,
+) {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
@@ -35,23 +40,14 @@ class SecurityConfiguration {
     }
 
     @Bean
-    fun jwtDecoder(resourceServerProperties: OAuth2ResourceServerProperties): JwtDecoder {
-        val issuerUri = resourceServerProperties.jwt.issuerUri
+    fun audValidator(resourceServerProperties: OAuth2ResourceServerProperties): OAuth2TokenValidator<Jwt?> {
         val allowedAudiences = resourceServerProperties.jwt.audiences
-
-        return JwtDecoders.fromIssuerLocation<NimbusJwtDecoder>(issuerUri).apply {
-            setJwtValidator(
-                DelegatingOAuth2TokenValidator(
-                    //JwtTimestampValidator(),
-                    JwtIssuerValidator(issuerUri),
-                    JwtClaimValidator<String>("acr") { it == "Level4" || it == "idporten-loa-high" },
-                    JwtClaimValidator(AUD) { aud: List<String>? ->
-                        aud?.any { allowedAudiences.contains(it) } ?: false
-                    },
-                    //JwtClaimValidator<String>("azp") {  it?.isNotBlank() ?: false},
-                    //JwtClaimValidator<String>("azp_name") { it?.isNotBlank() ?: false },
-                )
-            )
+        return JwtClaimValidator<List<String>>(AUD) { aud  ->
+            aud.any { allowedAudiences.contains(it) }
         }
     }
+
+    @Bean
+    fun acrValidator(): OAuth2TokenValidator<Jwt?> =
+        JwtClaimValidator<List<String>>("acr") { it.contains("Level4")  || it.contains("idporten-loa-high")}
 }


### PR DESCRIPTION
~Man skal tydeligvis ikke sjekke aud mot idporten, men client_id, lærte jeg nettopp av nais docs.~ blanda sammen tokenx og idporten ...

Har ikke testet dette (fikk noen problemer med kjøring lokalt), men virker fra doc-en som man skal kunne injecte spesifikke claims. Ble litt usikker på om default-sjekkene forsvant når man lager `jwtDecoder: JwtDecoder`-bean.