### PR TITLE
/api/userInfo/v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-reactor</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoController.kt
@@ -105,7 +105,7 @@ class UserInfoController(
                                 id = id,
                                 tjenestekode = tjeneste.tjenestekode,
                                 tjenesteversjon = tjeneste.tjenesteversjon,
-                                organisasjoner = organisasjonerBasertPaRettigheter
+                                organisasjoner = organisasjonerBasertPaRettigheter.mapNotNull { it.organizationNumber }
                             )
                         }
                     }
@@ -115,6 +115,11 @@ class UserInfoController(
             val organisasjoner = async {
                 runCatching {
                     altinnService.hentOrganisasjoner(authenticatedUserHolder.fnr)
+                        .filter {
+                            it.organizationForm == "BEDR"
+                                    || it.organizationForm == "AAFY"
+                                    || it.type == "Enterprise"
+                        }
                 }
             }.await()
 
@@ -137,7 +142,7 @@ class UserInfoController(
             val id: String,
             val tjenestekode: String,
             val tjenesteversjon: String,
-            val organisasjoner: List<Organisasjon>,
+            val organisasjoner: List<String>,
         )
     }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoController.kt
@@ -1,0 +1,147 @@
+package no.nav.arbeidsgiver.min_side.userinfo
+
+import no.nav.arbeidsgiver.min_side.config.GittMiljø
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder
+import no.nav.arbeidsgiver.min_side.models.Organisasjon
+import no.nav.arbeidsgiver.min_side.services.altinn.AltinnService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class UserInfoController(
+    private val altinnService: AltinnService,
+    private val authenticatedUserHolder: AuthenticatedUserHolder,
+    gittMiljø: GittMiljø,
+) {
+
+    val tjenester = mapOf(
+        "ekspertbistand" to Altinnskjema(
+            tjenestekode = "5384",
+            tjenesteversjon = "1",
+        ),
+        "inntektsmelding" to Altinnskjema(
+            tjenestekode = "4936",
+            tjenesteversjon = "1",
+        ),
+        "utsendtArbeidstakerEØS" to Altinnskjema(
+            tjenestekode = "4826",
+            tjenesteversjon = "1",
+        ),
+        "arbeidstrening" to NAVTjeneste(
+            tjenestekode = "5332",
+            tjenesteversjon = gittMiljø.resolve(
+                prod = { "2" },
+                other = { "1" },
+            ),
+        ),
+        "arbeidsforhold" to NAVTjeneste(
+            tjenestekode = "5441",
+            tjenesteversjon = "1",
+        ),
+        "midlertidigLønnstilskudd" to NAVTjeneste(
+            tjenestekode = "5516",
+            tjenesteversjon = "1",
+        ),
+        "varigLønnstilskudd" to NAVTjeneste(
+            tjenestekode = "5516",
+            tjenesteversjon = "2",
+        ),
+        "sommerjobb" to NAVTjeneste(
+            tjenestekode = "5516",
+            tjenesteversjon = "3",
+        ),
+        "mentortilskudd" to NAVTjeneste(
+            tjenestekode = "5516",
+            tjenesteversjon = "4",
+        ),
+        "inkluderingstilskudd" to NAVTjeneste(
+            tjenestekode = "5516",
+            tjenesteversjon = "5",
+        ),
+        "sykefravarstatistikk" to NAVTjeneste(
+            tjenestekode = "3403",
+            tjenesteversjon = gittMiljø.resolve(
+                prod = { "2" },
+                other = { "1" },
+            ),
+        ),
+        "forebyggefravar" to NAVTjeneste(
+            tjenestekode = "5934",
+            tjenesteversjon = "1",
+        ),
+        "rekruttering" to NAVTjeneste(
+            tjenestekode = "5078",
+            tjenesteversjon = "1",
+        ),
+        "tilskuddsbrev" to NAVTjeneste(
+            tjenestekode = "5278",
+            tjenesteversjon = "1",
+        ),
+        "yrkesskade" to NAVTjeneste(
+            tjenestekode = "5902",
+            tjenesteversjon = "1",
+        ),
+    )
+
+    @GetMapping("/api/userInfo/v1")
+    fun getUserInfo(): UserInfoRespons {
+        val organisasjoner = altinnService.hentOrganisasjoner(authenticatedUserHolder.fnr)
+        val tilganger = tjenester.mapNotNull { (id, tjeneste) ->
+            val organisasjonerBasertPaRettigheter = altinnService.hentOrganisasjonerBasertPaRettigheter(
+                authenticatedUserHolder.fnr,
+                tjeneste.tjenestekode,
+                tjeneste.tjenesteversjon
+            )
+            if (organisasjonerBasertPaRettigheter.isEmpty()) {
+                null
+            } else {
+                UserInfoRespons.Tilgang(
+                    id = id,
+                    tjenestekode = tjeneste.tjenestekode,
+                    tjenesteversjon = tjeneste.tjenesteversjon,
+                    organisasjoner = organisasjonerBasertPaRettigheter
+                )
+            }
+        }
+
+        return UserInfoRespons(
+            organisasjoner = organisasjoner,
+            tilganger = tilganger,
+        )
+    }
+
+    data class UserInfoRespons(
+        val organisasjoner: List<Organisasjon>,
+        val tilganger: List<Tilgang>,
+    ) {
+        data class Tilgang(
+            val id: String,
+            val tjenestekode: String,
+            val tjenesteversjon: String,
+            val organisasjoner: List<Organisasjon>,
+        )
+    }
+
+
+    sealed interface Tjeneste {
+        val sort: Sort
+        val tjenestekode: String
+        val tjenesteversjon: String
+    }
+
+    data class NAVTjeneste(
+        override val tjenestekode: String,
+        override val tjenesteversjon: String,
+    ) : Tjeneste {
+        override val sort = Sort.tjeneste
+    }
+
+    data class Altinnskjema(
+        override val tjenestekode: String,
+        override val tjenesteversjon: String,
+    ) : Tjeneste {
+        override val sort = Sort.skjema
+    }
+
+    enum class Sort { tjeneste, skjema }
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoController.kt
@@ -89,7 +89,7 @@ class UserInfoController(
     @GetMapping("/api/userInfo/v1")
     suspend fun getUserInfo(): UserInfoRespons {
         val (tilganger, organisasjoner) = supervisorScope {
-            val tjenester = tjenester.map { (id, tjeneste) ->
+            val tilganger = tjenester.map { (id, tjeneste) ->
                 async {
                     runCatching {
                         val organisasjonerBasertPaRettigheter = altinnService.hentOrganisasjonerBasertPaRettigheter(
@@ -118,7 +118,7 @@ class UserInfoController(
                 }
             }.await()
 
-            tjenester to organisasjoner
+            tilganger to organisasjoner
         }
 
         return UserInfoRespons(

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/controller/SecurityMockMvcUtil.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/controller/SecurityMockMvcUtil.kt
@@ -1,15 +1,18 @@
 package no.nav.arbeidsgiver.min_side.controller
 
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
 
 class SecurityMockMvcUtil {
     companion object {
-        fun jwtWithPid(pid: String): SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor {
-            return SecurityMockMvcRequestPostProcessors.jwt()
-                .jwt { jwt ->
-                    jwt.claim("pid", pid)
-                }
-        }
-
+        fun jwtWithPid(
+            pid: String,
+            configure: Jwt.Builder.() -> Unit = {},
+        ): JwtRequestPostProcessor =
+            jwt().jwt { jwt ->
+                jwt.claim("pid", pid)
+                jwt.configure()
+            }
     }
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoControllerTest.kt
@@ -54,7 +54,9 @@ class UserInfoControllerTest {
                 Organisasjon(
                     name = "overenhet",
                     organizationNumber = "1",
-                    organizationForm = "AS"
+                    organizationForm = "AS",
+                    type = "Enterprise"
+
                 ),
             )
         )
@@ -101,7 +103,7 @@ class UserInfoControllerTest {
                                   },
                                   {
                                       "Name": "overenhet",
-                                      "Type": null,
+                                      "Type": "Enterprise",
                                       "ParentOrganizationNumber": null,
                                       "OrganizationNumber": "1",
                                       "OrganizationForm": "AS",
@@ -113,15 +115,7 @@ class UserInfoControllerTest {
                                         "id": "sykefravarstatistikk",
                                         "tjenestekode": "3403",
                                         "tjenesteversjon": "1",
-                                        "organisasjoner": [
-                                        {
-                                            "Name": "underenhet",
-                                            "Type": null,
-                                            "ParentOrganizationNumber": "1",
-                                            "OrganizationNumber": "10",
-                                            "OrganizationForm": "BEDR",
-                                            "Status": null
-                                        }]
+                                        "organisasjoner": [ "10" ]
                                     }
                                 ]
                             }

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoControllerTest.kt
@@ -1,0 +1,136 @@
+package no.nav.arbeidsgiver.min_side.userinfo
+
+import no.nav.arbeidsgiver.min_side.SecurityConfiguration
+import no.nav.arbeidsgiver.min_side.config.GittMiljø
+import no.nav.arbeidsgiver.min_side.controller.AuthenticatedUserHolder
+import no.nav.arbeidsgiver.min_side.controller.SecurityMockMvcUtil.Companion.jwtWithPid
+import no.nav.arbeidsgiver.min_side.models.Organisasjon
+import no.nav.arbeidsgiver.min_side.services.altinn.AltinnService
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.`when`
+import org.skyscreamer.jsonassert.JSONAssert
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@MockBean(JwtDecoder::class)
+@WebMvcTest(
+    value = [
+        UserInfoController::class,
+        SecurityConfiguration::class,
+        AuthenticatedUserHolder::class,
+        GittMiljø::class,
+    ],
+    properties = [
+        "server.servlet.context-path=/"
+    ]
+)
+class UserInfoControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockBean
+    lateinit var altinnService: AltinnService
+
+    @Test
+    fun `returnerer organisasjoner og rettigheter for innlogget bruker`() {
+        `when`(altinnService.hentOrganisasjoner("42")).thenReturn(
+            listOf(
+                Organisasjon(
+                    name = "underenhet",
+                    parentOrganizationNumber = "1",
+                    organizationNumber = "10",
+                    organizationForm = "BEDR"
+                ),
+                Organisasjon(
+                    name = "overenhet",
+                    organizationNumber = "1",
+                    organizationForm = "AS"
+                ),
+            )
+        )
+        `when`(altinnService.hentOrganisasjonerBasertPaRettigheter(anyString(), anyString(), anyString())).then {
+            if (it.arguments[1] == "3403" && it.arguments[2] == "1") {
+                listOf(
+                    Organisasjon(
+                        name = "underenhet",
+                        parentOrganizationNumber = "1",
+                        organizationNumber = "10",
+                        organizationForm = "BEDR"
+                    ),
+                )
+            } else {
+                emptyList()
+            }
+        }
+
+        mockMvc
+            .perform(
+                get("/api/userInfo/v1")
+                    .with(jwtWithPid("42"))
+            )
+            .andDo(print())
+            .andExpect(status().isOk)
+            .andReturn().response.contentAsString.let {
+                JSONAssert.assertEquals(
+                    """
+                    {
+                      "organisasjoner": [
+                          {
+                              "Name": "underenhet",
+                              "Type": null,
+                              "ParentOrganizationNumber": "1",
+                              "OrganizationNumber": "10",
+                              "OrganizationForm": "BEDR",
+                              "Status": null
+                          },
+                          {
+                              "Name": "overenhet",
+                              "Type": null,
+                              "ParentOrganizationNumber": null,
+                              "OrganizationNumber": "1",
+                              "OrganizationForm": "AS",
+                              "Status": null
+                          }
+                        ],
+                        "tilganger": [
+                            {
+                                "id": "sykefravarstatistikk",
+                                "tjenestekode": "3403",
+                                "tjenesteversjon": "1",
+                                "organisasjoner": [
+                                {
+                                    "Name": "underenhet",
+                                    "Type": null,
+                                    "ParentOrganizationNumber": "1",
+                                    "OrganizationNumber": "10",
+                                    "OrganizationForm": "BEDR",
+                                    "Status": null
+                                }]
+                            }
+                        ]
+                    }
+                    """,
+                    it,
+                    true
+                )
+            }
+    }
+
+    @Test
+    fun `returnerer http 401 for ikke innlogget bruker`() {
+        mockMvc
+            .perform(
+                get("/api/userInfo/v1")
+                    .with(anonymous())
+            )
+            .andExpect(status().isUnauthorized)
+    }
+}


### PR DESCRIPTION
Planen for frontend er som følger
* erstatt kall til isLoggedIn med kall til /userInfo/v1
* erstatt kall til api/organisasjoner fra hentorganisasjoner til å bruke data fra userInfo
* erstatt kall til hentAltinntilganger til å bruker data fra userInfo

Utlisting av skjema og tjenester blir liggende dobbelt opp i første omgang, da det er flere ting som bruker `tjenester.ts`.
På sikt bør dette kanskje bo ett sted, men det kan vi se på siden.

---

* https://github.com/navikt/min-side-arbeidsgiver/pull/1653
* [x] test i dev