### PR TITLE
HttpClient for alltins kofuvi-endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
@@ -47,7 +47,7 @@ class KontaktinfoClient(
         }
 
         val officialcontacts = restTemplate.exchange(
-            "api/serviceowner/organizations/{organizationNumber}/officialcontacts?ForceEIAuthentication",
+            "/api/serviceowner/organizations/{organizationNumber}/officialcontacts?ForceEIAuthentication",
             GET,
             HttpEntity<Nothing>(headers),
             contactInfoListType,

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
@@ -36,8 +36,8 @@ class KontaktinfoClient(
         .build()
 
     data class Kontaktinfo(
-        val eposter: List<String>,
-        val telefonnumre: List<String>,
+        val eposter: Set<String>,
+        val telefonnumre: Set<String>,
     )
 
     fun hentKontaktinfo(orgnr: String): Kontaktinfo? {
@@ -60,8 +60,8 @@ class KontaktinfoClient(
          * HTTP/1.1 400 Invalid organization number: 0000000
          **/
 
-        val eposter = mutableListOf<String>()
-        val telefonnumre = mutableListOf<String>()
+        val eposter = mutableSetOf<String>()
+        val telefonnumre = mutableSetOf<String>()
 
         for (contact in officialcontacts) {
             if (contact.emailAddress.isNotBlank()) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.min_side.kontaktinfo
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.arbeidsgiver.min_side.clients.retryInterceptor
 import no.nav.arbeidsgiver.min_side.maskinporten.MaskinportenTokenService
@@ -78,6 +79,7 @@ class KontaktinfoClient(
         )
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private class ContactInfoDTO(
         @JsonProperty("MobileNumber")
         val mobileNumber: String,

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
@@ -18,8 +18,8 @@ import kotlin.collections.List
 @Component
 class KontaktinfoClient(
     restTemplateBuilder: RestTemplateBuilder,
-    @Value("altinn.apiBaseUrl") altinnApiBaseUrl: String,
-    @Value("altinn.altinnHeader") private val altinnApiKey: String,
+    @Value("\${altinn.apiBaseUrl}") altinnApiBaseUrl: String,
+    @Value("\${altinn.altinnHeader}") private val altinnApiKey: String,
     private val maskinportenTokenService: MaskinportenTokenService,
 ) {
     private val restTemplate = restTemplateBuilder
@@ -47,7 +47,7 @@ class KontaktinfoClient(
         }
 
         val officialcontacts = restTemplate.exchange(
-            "serviceowner/organizations/{organizationNumber}/officialcontacts?ForceEIAuthentication",
+            "api/serviceowner/organizations/{organizationNumber}/officialcontacts?ForceEIAuthentication",
             GET,
             HttpEntity<Nothing>(headers),
             contactInfoListType,

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
@@ -1,0 +1,91 @@
+package no.nav.arbeidsgiver.min_side.kontaktinfo
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import no.nav.arbeidsgiver.min_side.clients.retryInterceptor
+import no.nav.arbeidsgiver.min_side.maskinporten.MaskinportenTokenService
+import org.apache.http.NoHttpResponseException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod.GET
+import org.springframework.stereotype.Component
+import java.net.SocketException
+import javax.net.ssl.SSLHandshakeException
+import kotlin.collections.List
+
+@Component
+class KontaktinfoClient(
+    restTemplateBuilder: RestTemplateBuilder,
+    @Value("altinn.apiBaseUrl") altinnApiBaseUrl: String,
+    @Value("altinn.altinnHeader") private val altinnApiKey: String,
+    private val maskinportenTokenService: MaskinportenTokenService,
+) {
+    private val restTemplate = restTemplateBuilder
+        .rootUri(altinnApiBaseUrl)
+        .additionalInterceptors(
+            retryInterceptor(
+                3,
+                250L,
+                NoHttpResponseException::class.java,
+                SocketException::class.java,
+                SSLHandshakeException::class.java,
+            )
+        )
+        .build()
+
+    data class Kontaktinfo(
+        val eposter: List<String>,
+        val telefonnumre: List<String>,
+    )
+
+    fun hentKontaktinfo(orgnr: String): Kontaktinfo? {
+        val headers = HttpHeaders().apply {
+            set("apikey", altinnApiKey)
+            setBearerAuth(maskinportenTokenService.currentAccessToken())
+        }
+
+        val officialcontacts = restTemplate.exchange(
+            "serviceowner/organizations/{organizationNumber}/officialcontacts?ForceEIAuthentication",
+            GET,
+            HttpEntity<Nothing>(headers),
+            contactInfoListType,
+            mapOf(
+                "organizationNumber" to orgnr
+            )
+        ).body ?: throw RuntimeException("serviceowner/organizations/{orgnr}/officialcontacts got null body")
+
+        /* Ved ukjent orgnr returnerer altinn:
+         * HTTP/1.1 400 Invalid organization number: 0000000
+         **/
+
+        val eposter = mutableListOf<String>()
+        val telefonnumre = mutableListOf<String>()
+
+        for (contact in officialcontacts) {
+            if (contact.emailAddress.isNotBlank()) {
+                eposter.add(contact.emailAddress)
+            }
+            if (contact.mobileNumber.isNotBlank()) {
+                telefonnumre.add(contact.mobileNumber)
+            }
+        }
+
+        return Kontaktinfo(
+            eposter = eposter,
+            telefonnumre = telefonnumre,
+        )
+    }
+
+    private class ContactInfoDTO(
+        @JsonProperty("MobileNumber")
+        val mobileNumber: String,
+        @JsonProperty("EMailAddress")
+        val emailAddress: String,
+    )
+
+    companion object {
+        private val contactInfoListType = object : ParameterizedTypeReference<List<ContactInfoDTO>>() {}
+    }
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/maskinporten/MaskinportenTokenService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/maskinporten/MaskinportenTokenService.kt
@@ -3,20 +3,26 @@ package no.nav.arbeidsgiver.min_side.maskinporten
 import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.InitializingBean
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import java.lang.management.ManagementFactory
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicReference
 
+interface MaskinportenTokenService {
+    fun currentAccessToken(): String
+}
+
 @Component
-class MaskinportenTokenService(
+@Profile("dev-gcp", "prod-gcp")
+class MaskinportenTokenServiceImpl(
     private val maskinportenClient: MaskinportenClient,
     private val meterRegistry: MeterRegistry,
-): InitializingBean {
+): MaskinportenTokenService, InitializingBean {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val tokenStore = AtomicReference<TokenResponseWrapper?>()
 
-    fun currentAccessToken(): String {
+    override fun currentAccessToken(): String {
         val storedToken = tokenStore.get()
         val token = if (storedToken != null && storedToken.percentageRemaining() > 20.0) {
             storedToken

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,6 +54,7 @@ springdoc:
     enabled: true
   packagesToScan: no.nav.arbeidsgiver.min_side
 
+
 ---
 
 spring:
@@ -81,6 +82,7 @@ altinn:
   proxyUrl: http://altinn-proxy/altinn-rettigheter-proxy
   proxyFallbackUrl: http://altinn/altinn
   proxyAudience: fake:fake:fake
+  apiBaseUrl: "http://altinn.example.org/"
 
 ereg-services.baseUrl: "https://ereg-services.dev-fss-pub.nais.io"
 
@@ -108,6 +110,7 @@ altinn:
   proxyUrl: http://altinn-rettigheter-proxy.arbeidsgiver/altinn-rettigheter-proxy
   proxyFallbackUrl: https://api-gw-q1.oera.no
   proxyAudience: dev-gcp:arbeidsgiver:altinn-rettigheter-proxy
+  apiBaseUrl: "https://tt02.altinn.no/"
 
 ereg-services.baseUrl: "https://ereg-services.dev-fss-pub.nais.io"
 
@@ -134,6 +137,7 @@ altinn:
   proxyUrl: http://altinn-rettigheter-proxy.arbeidsgiver/altinn-rettigheter-proxy
   proxyFallbackUrl: https://api-gw.oera.no
   proxyAudience: prod-gcp:arbeidsgiver:altinn-rettigheter-proxy
+  apiBaseUrl: "https://www.altinn.no/"
 
 ereg-services.baseUrl: "https://ereg-services.prod-fss-pub.nais.io"
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,7 +82,7 @@ altinn:
   proxyUrl: http://altinn-proxy/altinn-rettigheter-proxy
   proxyFallbackUrl: http://altinn/altinn
   proxyAudience: fake:fake:fake
-  apiBaseUrl: "http://altinn.example.org/"
+  apiBaseUrl: "http://altinn.example.org"
 
 ereg-services.baseUrl: "https://ereg-services.dev-fss-pub.nais.io"
 
@@ -110,7 +110,7 @@ altinn:
   proxyUrl: http://altinn-rettigheter-proxy.arbeidsgiver/altinn-rettigheter-proxy
   proxyFallbackUrl: https://api-gw-q1.oera.no
   proxyAudience: dev-gcp:arbeidsgiver:altinn-rettigheter-proxy
-  apiBaseUrl: "https://tt02.altinn.no/"
+  apiBaseUrl: "https://tt02.altinn.no"
 
 ereg-services.baseUrl: "https://ereg-services.dev-fss-pub.nais.io"
 
@@ -137,7 +137,7 @@ altinn:
   proxyUrl: http://altinn-rettigheter-proxy.arbeidsgiver/altinn-rettigheter-proxy
   proxyFallbackUrl: https://api-gw.oera.no
   proxyAudience: prod-gcp:arbeidsgiver:altinn-rettigheter-proxy
-  apiBaseUrl: "https://www.altinn.no/"
+  apiBaseUrl: "https://www.altinn.no"
 
 ereg-services.baseUrl: "https://ereg-services.prod-fss-pub.nais.io"
 

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClientTest.kt
@@ -18,7 +18,6 @@ import org.springframework.web.client.HttpClientErrorException
     KontaktinfoClient::class,
     MaskinportenTokenServiceStub::class,
 )
-@ActiveProfiles("local")
 class KontaktinfoClientTest {
     @Autowired
     lateinit var altinnServer: MockRestServiceServer

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClientTest.kt
@@ -25,6 +25,10 @@ class KontaktinfoClientTest {
     @Autowired
     lateinit var kontaktinfoClient: KontaktinfoClient
 
+    /* NB. Har sjekket hvordan responsen påvirkes av sletting av kontaktinfo, og
+     * de slettede blir bare fjernet fra listen; ingen markering eller noe sånt noe.
+     */
+
     @Test
     fun telefonnummerErRegistrert() {
         mockKontaktinfoResponse(orgnr = "1", kunTelefonnumerResponse)
@@ -32,8 +36,8 @@ class KontaktinfoClientTest {
         val kontaktinfo = kontaktinfoClient.hentKontaktinfo("1")
         assertEquals(
             KontaktinfoClient.Kontaktinfo(
-                telefonnumre = listOf("+4711223344"),
-                eposter = listOf(),
+                telefonnumre = setOf("+4711223344"),
+                eposter = setOf(),
             ),
             kontaktinfo
         )
@@ -46,8 +50,8 @@ class KontaktinfoClientTest {
         val kontaktinfo = kontaktinfoClient.hentKontaktinfo("2")
         assertEquals(
             KontaktinfoClient.Kontaktinfo(
-                telefonnumre = listOf(),
-                eposter = listOf("test@test.no"),
+                telefonnumre = setOf(),
+                eposter = setOf("test@test.no"),
             ),
             kontaktinfo
         )
@@ -59,8 +63,8 @@ class KontaktinfoClientTest {
         val kontaktinfo = kontaktinfoClient.hentKontaktinfo("1234")
         assertEquals(
             KontaktinfoClient.Kontaktinfo(
-                telefonnumre = listOf("+4700112233"),
-                eposter = listOf("foo@example.com"),
+                telefonnumre = setOf("+4700112233"),
+                eposter = setOf("foo@example.com"),
             ),
             kontaktinfo
         )
@@ -74,8 +78,22 @@ class KontaktinfoClientTest {
         val kontaktinfo = kontaktinfoClient.hentKontaktinfo("3")
         assertEquals(
             KontaktinfoClient.Kontaktinfo(
-                telefonnumre = listOf(),
-                eposter = listOf(),
+                telefonnumre = setOf(),
+                eposter = setOf(),
+            ),
+            kontaktinfo
+        )
+    }
+
+    @Test
+    fun flereEposterRegistrert() {
+        mockKontaktinfoResponse(orgnr = "3", flereEposterRequest)
+
+        val kontaktinfo = kontaktinfoClient.hentKontaktinfo("3")
+        assertEquals(
+            KontaktinfoClient.Kontaktinfo(
+                telefonnumre = setOf("+4700112233"),
+                eposter = setOf("foo@example.com", "foo3@example.com", "foo2@example.com"),
             ),
             kontaktinfo
         )
@@ -155,3 +173,33 @@ private val ingenKontaktinfoResponse = """
     []
 """
 
+
+/* Legger på 3 eposter på en gang fra altinns GUI */
+private val flereEposterRequest = """
+    [
+      {
+        "MobileNumber": "+4700112233",
+        "MobileNumberChanged": "2021-10-05T13:04:19.367",
+        "EMailAddress": "",
+        "EMailAddressChanged": "0001-01-01T00:00:00"
+      },
+      {
+        "MobileNumber": "",
+        "MobileNumberChanged": "0001-01-01T00:00:00",
+        "EMailAddress": "foo@example.com",
+        "EMailAddressChanged": "2023-10-12T15:17:15.497"
+      },
+      {
+        "MobileNumber": "",
+        "MobileNumberChanged": "0001-01-01T00:00:00",
+        "EMailAddress": "foo3@example.com",
+        "EMailAddressChanged": "2023-10-12T15:38:44.297"
+      },
+      {
+        "MobileNumber": "",
+        "MobileNumberChanged": "0001-01-01T00:00:00",
+        "EMailAddress": "foo2@example.com",
+        "EMailAddressChanged": "2023-10-12T15:38:44.437"
+      }
+    ]
+"""

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClientTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest
+import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.client.MockRestServiceServer
@@ -17,7 +18,7 @@ import org.springframework.web.client.HttpClientErrorException
     KontaktinfoClient::class,
     MaskinportenTokenServiceStub::class,
 )
-@ActiveProfiles("test")
+@ActiveProfiles("local")
 class KontaktinfoClientTest {
     @Autowired
     lateinit var altinnServer: MockRestServiceServer
@@ -102,7 +103,7 @@ class KontaktinfoClientTest {
     @Test
     fun organisasjonFinnesIkke() {
         altinnServer.expect {
-            assertEquals("/serviceowner/organizations/1/officialcontacts", it.uri.path)
+            assertEquals("/api/serviceowner/organizations/1/officialcontacts", it.uri.path)
             assertNotNull("query-parameters må være gitt", it.uri.query)
             assertTrue(it.uri.query.contains("ForceEIAuthentication"))
         }.andRespond(withBadRequest())
@@ -116,7 +117,8 @@ class KontaktinfoClientTest {
 
     private fun mockKontaktinfoResponse(orgnr: String, response: String) =
         altinnServer.expect {
-            assertEquals("/serviceowner/organizations/${orgnr}/officialcontacts", it.uri.path)
+            assertEquals(HttpMethod.GET, it.method)
+            assertEquals("/api/serviceowner/organizations/${orgnr}/officialcontacts", it.uri.path)
             assertNotNull("query-parameters må være gitt", it.uri.query)
             assertTrue(it.uri.query.contains("ForceEIAuthentication"), "altinn forventer spesiell header for autentiserting")
             assertTrue(it.headers.getFirst("authorization")!!.startsWith("Bearer"), "bearer token må være satt")

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClientTest.kt
@@ -1,0 +1,157 @@
+package no.nav.arbeidsgiver.min_side.kontaktinfo
+
+import no.nav.arbeidsgiver.min_side.maskinporten.MaskinportenTokenServiceStub
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.HttpClientErrorException
+
+@RestClientTest(
+    KontaktinfoClient::class,
+    MaskinportenTokenServiceStub::class,
+)
+@ActiveProfiles("test")
+class KontaktinfoClientTest {
+    @Autowired
+    lateinit var altinnServer: MockRestServiceServer
+
+    @Autowired
+    lateinit var kontaktinfoClient: KontaktinfoClient
+
+    @Test
+    fun telefonnummerErRegistrert() {
+        mockKontaktinfoResponse(orgnr = "1", kunTelefonnumerResponse)
+
+        val kontaktinfo = kontaktinfoClient.hentKontaktinfo("1")
+        assertEquals(
+            KontaktinfoClient.Kontaktinfo(
+                telefonnumre = listOf("+4711223344"),
+                eposter = listOf(),
+            ),
+            kontaktinfo
+        )
+    }
+
+    @Test
+    fun epostErRegistrert() {
+        mockKontaktinfoResponse(orgnr = "2", kunEpostResponse)
+
+        val kontaktinfo = kontaktinfoClient.hentKontaktinfo("2")
+        assertEquals(
+            KontaktinfoClient.Kontaktinfo(
+                telefonnumre = listOf(),
+                eposter = listOf("test@test.no"),
+            ),
+            kontaktinfo
+        )
+    }
+
+    @Test
+    fun bådeTlfOgEpostRegistrert() {
+        mockKontaktinfoResponse(orgnr = "1234", bådeTlfOgEpostResponse)
+        val kontaktinfo = kontaktinfoClient.hentKontaktinfo("1234")
+        assertEquals(
+            KontaktinfoClient.Kontaktinfo(
+                telefonnumre = listOf("+4700112233"),
+                eposter = listOf("foo@example.com"),
+            ),
+            kontaktinfo
+        )
+
+    }
+
+    @Test
+    fun ingenKontaktinfoRegistrert() {
+        mockKontaktinfoResponse(orgnr = "3", ingenKontaktinfoResponse)
+
+        val kontaktinfo = kontaktinfoClient.hentKontaktinfo("3")
+        assertEquals(
+            KontaktinfoClient.Kontaktinfo(
+                telefonnumre = listOf(),
+                eposter = listOf(),
+            ),
+            kontaktinfo
+        )
+    }
+
+    @Test
+    fun organisasjonFinnesIkke() {
+        altinnServer.expect {
+            assertEquals("/serviceowner/organizations/1/officialcontacts", it.uri.path)
+            assertNotNull("query-parameters må være gitt", it.uri.query)
+            assertTrue(it.uri.query.contains("ForceEIAuthentication"))
+        }.andRespond(withBadRequest())
+
+        /* Hvis orgnr ikke finnes får man responsen:
+         * HTTP/1.1 400 Invalid organization number: 0000000 */
+        assertThrows<HttpClientErrorException.BadRequest> {
+            kontaktinfoClient.hentKontaktinfo("1")
+        }
+    }
+
+    private fun mockKontaktinfoResponse(orgnr: String, response: String) =
+        altinnServer.expect {
+            assertEquals("/serviceowner/organizations/${orgnr}/officialcontacts", it.uri.path)
+            assertNotNull("query-parameters må være gitt", it.uri.query)
+            assertTrue(it.uri.query.contains("ForceEIAuthentication"), "altinn forventer spesiell header for autentiserting")
+            assertTrue(it.headers.getFirst("authorization")!!.startsWith("Bearer"), "bearer token må være satt")
+            assertTrue(it.headers.getFirst("apikey")!!.isNotBlank(), "apikey må være satt" )
+        }.andRespond(
+            withSuccess(response, APPLICATION_JSON)
+        )
+}
+
+/* Hentet ved kall mot tt02.altinn.no */
+private val kunTelefonnumerResponse = """
+    [
+      {
+        "MobileNumber": "+4711223344",
+        "MobileNumberChanged": "2021-10-05T13:04:19.367",
+        "EMailAddress": "",
+        "EMailAddressChanged": "0001-01-01T00:00:00"
+      }
+    ]
+"""
+
+/* Hentet ved kall mot tt02.altinn.no */
+private val kunEpostResponse = """
+    [
+  {
+    "MobileNumber": "",
+    "MobileNumberChanged": "0001-01-01T00:00:00",
+    "EMailAddress": "test@test.no",
+    "EMailAddressChanged": "2021-03-15T10:42:08.287"
+  }
+]
+"""
+
+/*  Hentet fra tt02.altinn.no */
+private val bådeTlfOgEpostResponse = """
+[
+    {
+        "MobileNumber": "+4700112233",
+        "MobileNumberChanged": "2021-10-05T13:04:19.367",
+        "EMailAddress": "",
+        "EMailAddressChanged": "0001-01-01T00:00:00"
+    },
+    {
+        "MobileNumber": "",
+        "MobileNumberChanged": "0001-01-01T00:00:00",
+        "EMailAddress": "foo@example.com",
+        "EMailAddressChanged": "2023-10-12T15:17:15.497"
+    }
+]
+"""
+
+/* Hentet fra kall mot tt02.altinn.no */
+private val ingenKontaktinfoResponse = """
+    []
+"""
+

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/maskinporten/MaskinportenStubs.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/maskinporten/MaskinportenStubs.kt
@@ -21,3 +21,8 @@ class MaskinportenClientStub: MaskinportenClient {
     }
 }
 
+@Component
+@Profile("local", "test")
+class MaskinportenTokenServiceStub: MaskinportenTokenService {
+    override fun currentAccessToken() = "fake.maskinporten.token"
+}


### PR DESCRIPTION
Implisitt testet i dev via #330. ✅ 

Lager denne som egen PR, siden jeg må se på autorisering for visning av kontaktinfo på nytt, men klienten kan være nyttig for å slutte a vise den andre feilen ved feilende varsel.