### PR TITLE
clear varsling status vha poll av kontaktinfo

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollerRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollerRepository.kt
@@ -9,11 +9,11 @@ class KontaktInfoPollerRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
 
-    fun schedulePoll(virksomheterMedFeil: List<String>, poll_tidspunkt: String) {
+    fun schedulePoll(virksomheterMedFeil: List<String>, pollTidspunkt: String) {
         jdbcTemplate.batchUpdate("""
                 insert into poll_kontaktinfo (virksomhetsnummer, poll_tidspunkt) values (?, ?)
                     on conflict (virksomhetsnummer) do update set poll_tidspunkt = EXCLUDED.poll_tidspunkt;
-            """, virksomheterMedFeil.map { arrayOf(it, poll_tidspunkt) })
+            """, virksomheterMedFeil.map { arrayOf(it, pollTidspunkt) })
     }
 
     fun updateKontaktInfo(

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollerRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollerRepository.kt
@@ -1,0 +1,61 @@
+package no.nav.arbeidsgiver.min_side.varslingstatus
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import java.time.Instant
+
+@Repository
+class KontaktInfoPollerRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+
+    fun schedulePoll(virksomheterMedFeil: List<String>, poll_tidspunkt: String) {
+        jdbcTemplate.batchUpdate("""
+                insert into poll_kontaktinfo (virksomhetsnummer, poll_tidspunkt) values (?, ?)
+                    on conflict (virksomhetsnummer) do update set poll_tidspunkt = EXCLUDED.poll_tidspunkt;
+            """, virksomheterMedFeil.map { arrayOf(it, poll_tidspunkt) })
+    }
+
+    fun updateKontaktInfo(
+        virksomhetsnummer: String,
+        harEpost: Boolean,
+        harTlf: Boolean
+    ) {
+        jdbcTemplate.update(
+            """
+                    insert into kontaktinfo_resultat (virksomhetsnummer, sjekket_tidspunkt, har_epost, har_tlf) 
+                    values (?, ?, ?, ?)
+                        on conflict (virksomhetsnummer) do update 
+                            set sjekket_tidspunkt = EXCLUDED.sjekket_tidspunkt,
+                                har_epost = EXCLUDED.har_epost,
+                                har_tlf = EXCLUDED.har_tlf;
+                """,
+            virksomhetsnummer,
+            Instant.now().toString(),
+            harEpost,
+            harTlf
+        )
+    }
+
+    fun getAndDeleteForPoll(): String? {
+        val virksomhetsnummer = jdbcTemplate.queryForList(
+            """
+                select virksomhetsnummer
+                    from poll_kontaktinfo
+                    where poll_tidspunkt < ?
+                    order by poll_tidspunkt
+                    limit 1
+                    for update skip locked;
+            """,
+            Instant.now().toString()
+        ).firstOrNull()?.let { it["virksomhetsnummer"] as String } ?: return null
+
+        jdbcTemplate.update(
+            """
+                delete from poll_kontaktinfo where virksomhetsnummer = ?;
+            """,
+            virksomhetsnummer
+        )
+        return virksomhetsnummer
+    }
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingService.kt
@@ -1,11 +1,13 @@
 package no.nav.arbeidsgiver.min_side.varslingstatus
 
 import no.nav.arbeidsgiver.min_side.kontaktinfo.KontaktinfoClient
+import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
+@Profile("dev-gcp", "prod-gcp")
 @Service
 class KontaktInfoPollingService(
     private val varslingStatusRepository: VarslingStatusRepository,

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingService.kt
@@ -1,0 +1,52 @@
+package no.nav.arbeidsgiver.min_side.varslingstatus
+
+import no.nav.arbeidsgiver.min_side.kontaktinfo.KontaktinfoClient
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class KontaktInfoPollingService(
+    private val varslingStatusRepository: VarslingStatusRepository,
+    private val kontaktinfoClient: KontaktinfoClient,
+    private val kontaktInfoPollerRepository: KontaktInfoPollerRepository,
+) {
+    @Scheduled(
+        initialDelayString = "PT1M",
+        fixedDelayString = "PT60M",
+    )
+    fun schedulePolling() {
+        val virksomheterMedFeil = varslingStatusRepository.hentVirksomheterMedFeil()
+        kontaktInfoPollerRepository.schedulePoll(
+            virksomheterMedFeil,
+            Instant.now().toString()
+        )
+    }
+
+
+    @Scheduled(
+        initialDelayString = "PT1M",
+        fixedDelayString = "PT1S",
+    )
+    @Transactional
+    fun pollAndPullKontaktInfo() {
+        val virksomhetsnummer = kontaktInfoPollerRepository.getAndDeleteForPoll() ?: return
+        val kontaktInfo = kontaktinfoClient.hentKontaktinfo(virksomhetsnummer) ?: return
+
+        kontaktInfoPollerRepository.updateKontaktInfo(
+            virksomhetsnummer,
+            kontaktInfo.eposter.isNotEmpty(),
+            kontaktInfo.telefonnumre.isNotEmpty()
+        )
+    }
+
+    @Scheduled(
+        initialDelayString = "PT1M",
+        fixedDelayString = "PT1H",
+    )
+    fun cleanupOldAndOk() {
+        // TODO: cleanup kontaktinfo_resultat where siste varsel_status = OK, or older than 3 months
+    }
+
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingService.kt
@@ -61,7 +61,7 @@ class KontaktInfoPollingService(
 
     private fun finnKontaktinfoIOrgTre(virksomhetsnummer: String) =
         kontaktinfoClient.hentKontaktinfo(virksomhetsnummer)
-            ?: eregService.hentOverenhet(virksomhetsnummer)?.organizationNumber
+            ?: eregService.hentUnderenhet(virksomhetsnummer)?.parentOrganizationNumber
                 ?.let { kontaktinfoClient.hentKontaktinfo(it) }
 
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepository.kt
@@ -64,7 +64,9 @@ class VarslingStatusRepository(
             join newest_statuses
                 on vs.virksomhetsnummer = newest_statuses.virksomhetsnummer 
                 and vs.status_tidspunkt = newest_statuses.newest_status_timestamp
-            where vs.status = 'MANGLER_KOFUVI';
+            left join kontaktinfo_resultat ki on vs.virksomhetsnummer = ki.virksomhetsnummer
+                where (ki is null or (ki.har_epost = false and ki.har_tlf = false)) 
+                and vs.status = 'MANGLER_KOFUVI';
             """
         ).map { it["virksomhetsnummer"] as String }
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepository.kt
@@ -54,16 +54,17 @@ class VarslingStatusRepository(
     fun hentVirksomheterMedFeil(): List<String> {
         return jdbcTemplate.queryForList(
             """
+            with newest_statuses as (
+                select virksomhetsnummer, max(status_tidspunkt) as newest_status_timestamp
+                from varsling_status
+                group by virksomhetsnummer
+            ) 
             select vs.*
-                from varsling_status vs
-                    join (
-                        select virksomhetsnummer, max(status_tidspunkt) as newest_status_timestamp
-                            from varsling_status
-                            group by virksomhetsnummer
-                    ) newest_statuses
+            from varsling_status vs
+            join newest_statuses
                 on vs.virksomhetsnummer = newest_statuses.virksomhetsnummer 
-                    and vs.status_tidspunkt = newest_statuses.newest_status_timestamp
-                where vs.status = 'MANGLER_KOFUVI';
+                and vs.status_tidspunkt = newest_statuses.newest_status_timestamp
+            where vs.status = 'MANGLER_KOFUVI';
             """
         ).map { it["virksomhetsnummer"] as String }
     }

--- a/src/main/resources/db/migration/V11__clear_varsling_status.sql
+++ b/src/main/resources/db/migration/V11__clear_varsling_status.sql
@@ -1,0 +1,15 @@
+create table poll_kontaktinfo
+(
+    virksomhetsnummer text not null primary key,
+    poll_tidspunkt     text not null
+);
+
+create table kontaktinfo_resultat
+(
+    virksomhetsnummer text not null primary key,
+    sjekket_tidspunkt text not null,
+    har_epost         boolean,
+    har_tlf           boolean
+);
+
+

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollerRepositoryTest.kt
@@ -1,0 +1,102 @@
+package no.nav.arbeidsgiver.min_side.varslingstatus
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import java.time.Instant
+import kotlin.time.Duration.Companion.days
+import kotlin.time.toJavaDuration
+
+@MockBean(JwtDecoder::class)
+@SpringBootTest(
+    properties = [
+        "spring.flyway.cleanDisabled=false",
+    ]
+)
+class KontaktInfoPollerRepositoryTest {
+
+    @Autowired
+    lateinit var varslingStatusRepository: VarslingStatusRepository
+
+    @Autowired
+    lateinit var kontaktInfoPollerRepository: KontaktInfoPollerRepository
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    lateinit var varslingStatusKafkaListener: VarslingStatusKafkaListener
+
+    @Autowired
+    lateinit var flyway: Flyway
+
+    @BeforeEach
+    fun setup() {
+        flyway.clean()
+        flyway.migrate()
+        varslingStatusKafkaListener = VarslingStatusKafkaListener(
+            varslingStatusRepository,
+            objectMapper,
+        )
+    }
+
+    @Test
+    fun `sletter kontaktinfo med ok status eller eldre enn`() {
+        listOf(
+            // OK
+            Triple("OK", "42", Instant.now().toString()),
+
+            // OK and old
+            Triple("OK", "43", Instant.now().minus(2.days.toJavaDuration()).toString()),
+
+            // MANGLER_KOFUVI
+            Triple("MANGLER_KOFUVI", "314", Instant.now().toString()),
+
+            // MANGLER_KOFUVI and old
+            Triple("MANGLER_KOFUVI", "315", Instant.now().minus(2.days.toJavaDuration()).toString()),
+        ).forEachIndexed { index, (status, vnr, tidspunkt) ->
+            processVarslingStatus(
+                """
+                {
+                        "virksomhetsnummer": "$vnr",
+                        "varselId": "vid$index",
+                        "varselTimestamp": "2021-01-01T00:00:00",
+                        "kvittertEventTimestamp": "$tidspunkt",
+                        "status": "$status",
+                        "version": "1"
+                    }
+                """.trimIndent()
+            )
+            kontaktInfoPollerRepository.updateKontaktInfo(vnr, harEpost = true, harTlf = true)
+        }
+
+        kontaktInfoPollerRepository.slettKontaktinfoMedOkStatusEllerEldreEnn(1.days)
+
+        val kontaktinfo = jdbcTemplate.queryForList(
+            """
+           select * from kontaktinfo_resultat 
+        """
+        ).map { it["virksomhetsnummer"] as String }
+
+        assertEquals(listOf("314"), kontaktinfo)
+    }
+
+
+    private fun processVarslingStatus(value: String) {
+        varslingStatusKafkaListener.processVarslingStatus(
+            ConsumerRecord(
+                "", 0, 0, "", value
+            )
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepositoryTest.kt
@@ -23,6 +23,9 @@ class VarslingStatusRepositoryTest {
     lateinit var varslingStatusRepository: VarslingStatusRepository
 
     @Autowired
+    lateinit var kontaktInfoPollerRepository: KontaktInfoPollerRepository
+
+    @Autowired
     lateinit var objectMapper: ObjectMapper
 
     lateinit var varslingStatusKafkaListener: VarslingStatusKafkaListener
@@ -50,11 +53,15 @@ class VarslingStatusRepositoryTest {
             // 314 siste status = MANGLER_KOFUVI
             Triple("MANGLER_KOFUVI", "2021-01-03T00:00:00Z", "314"),
             Triple("OK", "2021-01-02T00:00:00Z", "314"),
+
+            // 333 siste status = MANGLER_KOFUVI, men har kontaktinfo fra poll
+            Triple("MANGLER_KOFUVI", "2021-01-03T00:00:00Z", "333"),
+            Triple("OK", "2021-01-02T00:00:00Z", "333"),
         ).forEachIndexed { index, (status, timestamp, vnr) ->
             processVarslingStatus(
                 """
                     {
-                        "virksomhetsnummer": "314",
+                        "virksomhetsnummer": "$vnr",
                         "varselId": "vid$index",
                         "varselTimestamp": "2021-01-01T00:00:00",
                         "kvittertEventTimestamp": "$timestamp",
@@ -64,6 +71,7 @@ class VarslingStatusRepositoryTest {
                 """
             )
         }
+        kontaktInfoPollerRepository.updateKontaktInfo("333", true, true)
 
         val result = varslingStatusRepository.hentVirksomheterMedFeil()
         assertEquals(listOf("314"), result)

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepositoryTest.kt
@@ -1,0 +1,78 @@
+package no.nav.arbeidsgiver.min_side.varslingstatus
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest(
+    properties = [
+        "server.servlet.context-path=/",
+        "spring.flyway.cleanDisabled=false",
+    ]
+)
+class VarslingStatusRepositoryTest {
+
+    @Autowired
+    lateinit var varslingStatusRepository: VarslingStatusRepository
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    lateinit var varslingStatusKafkaListener: VarslingStatusKafkaListener
+
+    @Autowired
+    lateinit var flyway: Flyway
+
+    @BeforeEach
+    fun setup() {
+        flyway.clean()
+        flyway.migrate()
+        varslingStatusKafkaListener = VarslingStatusKafkaListener(
+            varslingStatusRepository,
+            objectMapper,
+        )
+    }
+
+    @Test
+    fun `henter virksomheter som har MANGLER_KOFUVI som nyeste status`() {
+        listOf(
+            // 42 siste status = OK
+            Triple("OK", "2021-01-03T00:00:00Z", "42"),
+            Triple("MANGLER_KOFUVI", "2021-01-02T00:00:00Z", "42"),
+
+            // 314 siste status = MANGLER_KOFUVI
+            Triple("MANGLER_KOFUVI", "2021-01-03T00:00:00Z", "314"),
+            Triple("OK", "2021-01-02T00:00:00Z", "314"),
+        ).forEachIndexed { index, (status, timestamp, vnr) ->
+            processVarslingStatus(
+                """
+                    {
+                        "virksomhetsnummer": "314",
+                        "varselId": "vid$index",
+                        "varselTimestamp": "2021-01-01T00:00:00",
+                        "kvittertEventTimestamp": "$timestamp",
+                        "status": "$status",
+                        "version": "1"
+                    }
+                """
+            )
+        }
+
+        val result = varslingStatusRepository.hentVirksomheterMedFeil()
+        assertEquals(listOf("314"), result)
+    }
+
+
+    private fun processVarslingStatus(value: String) {
+        varslingStatusKafkaListener.processVarslingStatus(
+            ConsumerRecord(
+                "", 0, 0, "", value
+            )
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/VarslingStatusRepositoryTest.kt
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.oauth2.jwt.JwtDecoder
 
+@MockBean(JwtDecoder::class)
 @SpringBootTest(
     properties = [
-        "server.servlet.context-path=/",
         "spring.flyway.cleanDisabled=false",
     ]
 )


### PR DESCRIPTION
en polling service som har ansvar for å schedulere polling via tabell og utføre pull av kontaktinfo

varslingstatus repository tar hensyn til om kontaktinfo har blitt pollet og finnes

Gjenstår cleanup av rader, se todo i koden