### PR TITLE
Sjekk om kontaktinfo finnes på underenhet

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
@@ -39,9 +39,12 @@ class KontaktinfoClient(
     data class Kontaktinfo(
         val eposter: Set<String>,
         val telefonnumre: Set<String>,
-    )
+    ) {
+        val harKontaktinfo: Boolean
+            get() = eposter.isNotEmpty() || telefonnumre.isNotEmpty()
+    }
 
-    fun hentKontaktinfo(orgnr: String): Kontaktinfo? {
+    fun hentKontaktinfo(orgnr: String): Kontaktinfo {
         val headers = HttpHeaders().apply {
             set("apikey", altinnApiKey)
             setBearerAuth(maskinportenTokenService.currentAccessToken())

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingService.kt
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import kotlin.time.Duration.Companion.days
 
-@Profile("dev-gcp", "prod-gcp")
 @Service
 class KontaktInfoPollingService(
     private val varslingStatusRepository: VarslingStatusRepository,
@@ -59,9 +58,14 @@ class KontaktInfoPollingService(
         kontaktInfoPollerRepository.slettKontaktinfoMedOkStatusEllerEldreEnn(retention)
     }
 
-    private fun finnKontaktinfoIOrgTre(virksomhetsnummer: String) =
-        kontaktinfoClient.hentKontaktinfo(virksomhetsnummer)
-            ?: eregService.hentUnderenhet(virksomhetsnummer)?.parentOrganizationNumber
-                ?.let { kontaktinfoClient.hentKontaktinfo(it) }
+    private fun finnKontaktinfoIOrgTre(virksomhetsnummer: String): KontaktinfoClient.Kontaktinfo? {
+        val kontaktinfoUnderenhet = kontaktinfoClient.hentKontaktinfo(virksomhetsnummer)
+        if (kontaktinfoUnderenhet.harKontaktinfo) {
+            return kontaktinfoUnderenhet
+        }
+
+        return eregService.hentUnderenhet(virksomhetsnummer)?.parentOrganizationNumber
+            ?.let { kontaktinfoClient.hentKontaktinfo(it) }
+    }
 
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/varslingstatus/KontaktInfoPollingServiceTest.kt
@@ -1,0 +1,103 @@
+package no.nav.arbeidsgiver.min_side.varslingstatus
+
+import no.nav.arbeidsgiver.min_side.kontaktinfo.KontaktinfoClient
+import no.nav.arbeidsgiver.min_side.kontaktinfo.KontaktinfoClient.Kontaktinfo
+import no.nav.arbeidsgiver.min_side.models.Organisasjon
+import no.nav.arbeidsgiver.min_side.services.ereg.EregService
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+
+@SpringBootTest(
+    classes = [
+        KontaktInfoPollingService::class
+    ],
+    properties = [
+        "spring.flyway.cleanDisabled=false",
+    ]
+)
+@MockBean(VarslingStatusRepository::class)
+@MockBean(KontaktinfoClient::class)
+@MockBean(EregService::class)
+@MockBean(KontaktInfoPollerRepository::class)
+class KontaktInfoPollingServiceTest {
+    @Autowired
+    lateinit var kontaktInfoPollingService: KontaktInfoPollingService
+
+    @Autowired
+    lateinit var kontaktinfoPollerRepository: KontaktInfoPollerRepository
+
+    @Autowired
+    lateinit var kontaktinfoClient: KontaktinfoClient
+
+    @Autowired
+    lateinit var eregService: EregService
+
+
+    @Test
+    fun `bruker kofuvi for underenhet om den finnes`() {
+        // given
+        `when`(kontaktinfoPollerRepository.getAndDeleteForPoll()).thenReturn(underenhetOrgnr)
+        `when`(eregService.hentUnderenhet(underenhetOrgnr)).thenReturn(underenhet)
+        `when`(kontaktinfoClient.hentKontaktinfo(underenhetOrgnr)).thenReturn(kontaktinfoMedEpost)
+        `when`(kontaktinfoClient.hentKontaktinfo(hovedenhetOrgnr)).thenReturn(kontaktinfoMedTlf)
+
+        // when
+        kontaktInfoPollingService.pollAndPullKontaktInfo()
+
+        // then
+        verify(kontaktinfoPollerRepository).updateKontaktInfo(
+            underenhetOrgnr,
+            harEpost =  true,
+            harTlf = false,
+        )
+    }
+
+    @Test
+    fun `henter kofuvi for hovedenhet om det mangler kofuvi på underenhet`() {
+        // given
+        `when`(kontaktinfoPollerRepository.getAndDeleteForPoll()).thenReturn(underenhetOrgnr)
+        `when`(eregService.hentUnderenhet(underenhetOrgnr)).thenReturn(underenhet)
+        `when`(kontaktinfoClient.hentKontaktinfo(underenhetOrgnr)).thenReturn(ingenKontaktinfo)
+        `when`(kontaktinfoClient.hentKontaktinfo(hovedenhetOrgnr)).thenReturn(kontaktinfoMedEpost)
+
+        // when
+        kontaktInfoPollingService.pollAndPullKontaktInfo()
+
+        // then
+        verify(kontaktinfoPollerRepository).updateKontaktInfo(
+            underenhetOrgnr,
+            harEpost =  true,
+            harTlf = false,
+        )
+    }
+
+    companion object {
+        val underenhetOrgnr = "1".repeat(9)
+
+        val hovedenhetOrgnr = "2".repeat(9)
+
+        val underenhet = Organisasjon(
+            organizationNumber = underenhetOrgnr,
+            parentOrganizationNumber = hovedenhetOrgnr,
+        )
+
+        val ingenKontaktinfo =  Kontaktinfo(
+            eposter = setOf(),
+            telefonnumre = setOf(),
+        )
+
+        val kontaktinfoMedEpost =  Kontaktinfo(
+            eposter = setOf("post@example.com"),
+            telefonnumre = setOf(),
+        )
+
+        val kontaktinfoMedTlf=  Kontaktinfo(
+            eposter = setOf(),
+            telefonnumre = setOf("00000000"),
+        )
+    }
+}


### PR DESCRIPTION
Prøvde å kjøre analysen på nytt, nå som vi sjekker kofuvi, men fikk samme resultat som tidligere.

Vi bomma på sjekket for om underenheten har kontaktinfo. `KontaktinfoClient::hentKontaktinfo` hadde en misvisende nullable returtype, og kan faktisk ikke returnere null. Om kontaktinfo mangler, så er listene med eposter og telefonnumre tomme.