### PR TITLE
bump springboot 3.2 og fjern token-support-test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,12 +23,45 @@ jobs:
           --health-retries 5
         ports:
           - 2345:5432
-      fakedings:
-        image: ghcr.io/navikt/fakedings/fakedings:37fa232fd7feed67484d442d37f1e525625cad8b
+      mock-oauth2-server:
+        image: ghcr.io/navikt/mock-oauth2-server:2.0.1
         env:
-          OAUTH2_SERVER_HOST: "localhost"
+          JSON_CONFIG: >
+            {
+              "interactiveLogin": true,
+              "httpServer": "NettyWrapper",
+              "tokenCallbacks": [
+                {
+                  "issuerId": "faketokenx",
+                  "tokenExpiry": 600000,
+                  "requestMappings": [
+                    {
+                      "requestParam": "acr",
+                      "match": "Level4",
+                      "claims": {
+                        "sub": "42",
+                        "aud": "someaudience",
+                        "pid": "42",
+                        "acr": "Level4"
+                      }
+                    },
+                    {
+                      "requestParam": "acr",
+                      "match": "idporten-loa-high",
+                      "claims": {
+                        "sub": "42",
+                        "aud": "someaudience",
+                        "pid": "42",
+                        "acr": "idporten-loa-high"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+
         ports:
-          - 8080:8080
+          - 8118:8080
     steps:
       - uses: actions/checkout@v3
       - run: PGPASSWORD=postgres psql -U postgres -h localhost -p 2345 -f ./local-db-init.sql

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,12 @@ jobs:
           --health-retries 5
         ports:
           - 2345:5432
+      fakedings:
+        image: ghcr.io/navikt/fakedings/fakedings:37fa232fd7feed67484d442d37f1e525625cad8b
+        env:
+          OAUTH2_SERVER_HOST: "localhost"
+        ports:
+          - 8080:8080
     steps:
       - uses: actions/checkout@v3
       - run: PGPASSWORD=postgres psql -U postgres -h localhost -p 2345 -f ./local-db-init.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,44 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - ${PWD}/local-db-init.sql:/docker-entrypoint-initdb.d/init.sql
-  fakedings:
-    platform: linux/amd64
-    image: ghcr.io/navikt/fakedings/fakedings:37fa232fd7feed67484d442d37f1e525625cad8b
+  mock-oauth2-server:
+    image: ghcr.io/navikt/mock-oauth2-server:2.0.1
     ports:
-      - 8080:8080
-    hostname: localhost
+      - 8118:8080
+    environment:
+      JSON_CONFIG: >
+        {
+          "interactiveLogin": true,
+          "httpServer": "NettyWrapper",
+          "tokenCallbacks": [
+            {
+              "issuerId": "faketokenx",
+              "tokenExpiry": 600000,
+              "requestMappings": [
+                {
+                  "requestParam": "acr",
+                  "match": "Level4",
+                  "claims": {
+                    "sub": "42",
+                    "aud": "someaudience",
+                    "pid": "42",
+                    "acr": "Level4"
+                  }
+                },
+                {
+                  "requestParam": "acr",
+                  "match": "idporten-loa-high",
+                  "claims": {
+                    "sub": "42",
+                    "aud": "someaudience",
+                    "pid": "42",
+                    "acr": "idporten-loa-high"
+                  }
+                }
+              ]
+            }
+          ]
+        }
 
 volumes:
   database-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '2'
+version: '3'
 services:
   postgres:
     image: "postgres:12.11"
@@ -10,6 +10,12 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - ${PWD}/local-db-init.sql:/docker-entrypoint-initdb.d/init.sql
+  fakedings:
+    platform: linux/amd64
+    image: ghcr.io/navikt/fakedings/fakedings:37fa232fd7feed67484d442d37f1e525625cad8b
+    ports:
+      - 8080:8080
+    hostname: localhost
 
 volumes:
   database-data:

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.2.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -111,12 +111,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-validation-spring-test</artifactId>
-            <version>3.1.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,7 +84,7 @@ altinn:
   proxyAudience: fake:fake:fake
   apiBaseUrl: "http://altinn.example.org"
 
-ereg-services.baseUrl: "https://ereg-services.dev-fss-pub.nais.io"
+ereg-services.baseUrl: "https://localhost"
 
 token.x:
   privateJwk: fake

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/clients/altinn/AltinnTilgangssøknadClientTest.kt
@@ -3,7 +3,6 @@ package no.nav.arbeidsgiver.min_side.clients.altinn
 import no.nav.arbeidsgiver.min_side.models.AltinnTilgangssøknadsskjema
 import no.nav.arbeidsgiver.min_side.services.altinn.AltinnConfig
 import no.nav.arbeidsgiver.min_side.services.tokenExchange.ClientAssertionTokenFactory
-import no.nav.security.token.support.core.configuration.MultiIssuerConfiguration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,7 +15,7 @@ import org.springframework.test.web.client.MockRestServiceServer
 import org.springframework.test.web.client.match.MockRestRequestMatchers.*
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 
-@MockBean(MultiIssuerConfiguration::class, ClientAssertionTokenFactory::class)
+@MockBean(ClientAssertionTokenFactory::class)
 @RestClientTest(AltinnTilgangssøknadClient::class)
 @EnableConfigurationProperties(AltinnConfig::class)
 class AltinnTilgangssøknadClientTest {

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/controller/StorageIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/controller/StorageIntegrationTest.kt
@@ -12,7 +12,8 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest(
     properties = [

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/controller/TilgangsstyringUtføresTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/controller/TilgangsstyringUtføresTest.kt
@@ -1,36 +1,31 @@
 package no.nav.arbeidsgiver.min_side.controller
 
-import com.nimbusds.jose.JOSEObjectType
-import no.nav.security.mock.oauth2.MockOAuth2Server
-import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
 
 
 @SpringBootTest(
     properties = [
-        "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8118/issuer1"
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080/fake",
+        "spring.security.oauth2.resourceserver.jwt.audiences=someaudience"
     ]
 )
 @AutoConfigureMockMvc
 @ActiveProfiles("local")
-@EnableMockOAuth2Server(port = 8118)
 class TilgangsstyringUtføresTest {
     @Autowired
     lateinit var mockMvc: MockMvc
 
     @Autowired
-    lateinit var server: MockOAuth2Server
+    lateinit var restClientBuilder: RestClient.Builder
 
     @Test
     fun tilgangsstyringUtføres() {
@@ -42,7 +37,7 @@ class TilgangsstyringUtføresTest {
 
     @Test
     fun tilgangsstyringErOkForAcrLevel4() {
-        val token = token("42", mapOf("acr" to "Level4"))
+        val token = token("42", "Level4")
         mockMvc.get("/api/userInfo/v1") {
             header(AUTHORIZATION, "Bearer $token")
         }.andExpect {
@@ -52,7 +47,7 @@ class TilgangsstyringUtføresTest {
 
     @Test
     fun tilgangsstyringErOkForAcridportenLoaHigh() {
-        val token = token("42", mapOf("acr" to "idporten-loa-high"))
+        val token = token("42", "idporten-loa-high")
         mockMvc.get("/api/userInfo/v1") {
             header(AUTHORIZATION, "Bearer $token")
         }.andExpect {
@@ -60,18 +55,6 @@ class TilgangsstyringUtføresTest {
         }
     }
 
-    private fun token(subject: String, claims: Map<String, String>): String? {
-        return server.issueToken(
-            "issuer1",
-            "theclientid",
-            DefaultOAuth2TokenCallback(
-                "issuer1",
-                subject,
-                JOSEObjectType.JWT.type,
-                listOf("someaudience"),
-                claims + mapOf("pid" to subject),
-                3600
-            )
-        ).serialize()
-    }
+    private fun token(pid: String, acr: String): String? =
+        restClientBuilder.build().get().uri("http://localhost:8080/fake/tokenx?client_id=someclientid&aud=someaudience&pid=$pid&acr=$acr").retrieve().body()
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/controller/TilgangsstyringUtføresTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/controller/TilgangsstyringUtføresTest.kt
@@ -5,16 +5,17 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestClient
-import org.springframework.web.client.body
 
 
 @SpringBootTest(
     properties = [
-        "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080/fake",
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8118/faketokenx",
         "spring.security.oauth2.resourceserver.jwt.audiences=someaudience"
     ]
 )
@@ -37,7 +38,7 @@ class TilgangsstyringUtføresTest {
 
     @Test
     fun tilgangsstyringErOkForAcrLevel4() {
-        val token = token("42", "Level4")
+        val token = token(ACR.LEVEL4)
         mockMvc.get("/api/userInfo/v1") {
             header(AUTHORIZATION, "Bearer $token")
         }.andExpect {
@@ -47,7 +48,7 @@ class TilgangsstyringUtføresTest {
 
     @Test
     fun tilgangsstyringErOkForAcridportenLoaHigh() {
-        val token = token("42", "idporten-loa-high")
+        val token = token(ACR.IDPORTEN_LOA_HIGH)
         mockMvc.get("/api/userInfo/v1") {
             header(AUTHORIZATION, "Bearer $token")
         }.andExpect {
@@ -55,6 +56,35 @@ class TilgangsstyringUtføresTest {
         }
     }
 
-    private fun token(pid: String, acr: String): String? =
-        restClientBuilder.build().get().uri("http://localhost:8080/fake/tokenx?client_id=someclientid&aud=someaudience&pid=$pid&acr=$acr").retrieve().body()
+    private fun token(acr: ACR): String =
+        restClientBuilder
+            .build()
+            .post()
+            .uri("http://localhost:8118/faketokenx/token")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(
+                LinkedMultiValueMap<String, Any>().apply {
+                    add("audience", "someaudience")
+                    add("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+                    add("client_id", "fake")
+                    add("client_secret", "fake")
+                    add("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
+                    add("subject_token", subjectToken)
+                    add("acr", acr.value)
+                }
+            )
+            .retrieve()
+            .body(Map::class.java)?.get("access_token") as String
 }
+
+// subjectToken er hentet med en request mot fakedings: fakedings.intern.dev.nav.no/fake/idporten
+private val subjectToken = "eyJraWQiOiJmYWtlIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJhdF9oYXNoIjoiNTVkODlmZjYtMjY4OS00ZWI4LWI1Y2UtNTY0MjkwNWMwMWJiIiwic3ViIjoiYWNiZGQwMmUtMDE5NS00YWIxLWEzODYtZDI5ZmZiNmIyYjVmIiwiYW1yIjpbIkJhbmtJRCJdLCJpc3MiOiJodHRwczovL2Zha2VkaW5ncy5pbnRlcm4uZGV2Lm5hdi5uby9mYWtlIiwicGlkIjoiMTIzNDU2Nzg5MTAiLCJsb2NhbGUiOiJuYiIsImNsaWVudF9pZCI6Im5vdGZvdW5kIiwidGlkIjoiZGVmYXVsdCIsInNpZCI6IjA5ZWExOWY5LTM5ODktNDM5NS1iNjE3LTJiYTA3Zjk0NWIwMyIsImF1ZCI6Im5vdGZvdW5kIiwiYWNyIjoiaWRwb3J0ZW4tbG9hLWhpZ2giLCJuYmYiOjE3MDA4NDkyNjIsImF6cCI6Im5vdGZvdW5kIiwiYXV0aF90aW1lIjoxNzAwODQ5MjYyLCJleHAiOjE3MDA4NTI4NjIsImlhdCI6MTcwMDg0OTI2MiwianRpIjoiYTYzNmVmYjMtMzgzMC00ZDU4LThmY2YtNjgwYTk3MGNjN2NlIn0.eS-FO_ty1NOANYu7IHq5mKzVjaPavpl9lrMTq7oclHJ1ymDKxpkgsslR0eLaZ6sIz9VlNPve36iIG-W_GPZmV8RvGFb6RFVORzIIKSeW1Hh3IdnRm_C5d0W_RZ48V8LolRWtM-CVs9XoVTrK9LYxfRSRz-oOTCVSjbTJVKubWNc-G7GLNpqyPM2x2pMmffMnNZz9wM_7-mxCE9KQ0lAHwS4I-xHMBYfsiezPEgmL9K-bdbMP7syMMop8BtWdaLU56VkuDO-W6DOl2plK1P9udR_h29QlHoVxwpQfUxefGbb7jeqOpVzIc45LMNEUlWxC00zfZNb3LBstopyl06ghJg"
+
+/**
+ * ifølge [doken](https://github.com/navikt/mock-oauth2-server) skal det være mulig å ha dynamiske verdier med templating i JSON_CONFIG.
+ * Dette har jeg ikke fått til å fungere. Derfor er det en hardkodede verdier i JSON_CONFIG og en switch på acr requestParam
+ */
+private enum class ACR(val value: String) {
+    LEVEL4("Level4"), IDPORTEN_LOA_HIGH("idporten-loa-high")
+}
+

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/services/ereg/EregServiceTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/services/ereg/EregServiceTest.kt
@@ -1,7 +1,6 @@
 package no.nav.arbeidsgiver.min_side.services.ereg
 
 import no.nav.arbeidsgiver.min_side.services.tokenExchange.ClientAssertionTokenFactory
-import no.nav.security.token.support.core.configuration.MultiIssuerConfiguration
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,7 +15,7 @@ import org.springframework.test.web.client.match.MockRestRequestMatchers.request
 import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 
-@MockBean(MultiIssuerConfiguration::class, ClientAssertionTokenFactory::class)
+@MockBean(ClientAssertionTokenFactory::class)
 @RestClientTest(
     components = [EregService::class, EregCacheConfig::class],
 )

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/services/tokenExchange/TokenExchangeClientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/services/tokenExchange/TokenExchangeClientTest.kt
@@ -1,7 +1,6 @@
 package no.nav.arbeidsgiver.min_side.services.tokenExchange
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import no.nav.security.token.support.core.configuration.MultiIssuerConfiguration
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
@@ -15,7 +14,6 @@ import org.springframework.test.web.client.MockRestServiceServer
 import org.springframework.test.web.client.match.MockRestRequestMatchers.*
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 
-@MockBean(MultiIssuerConfiguration::class)
 @RestClientTest(
     components = [TokenExchangeClient::class],
     properties = [

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/tiltak/RefusjonStatusIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/tiltak/RefusjonStatusIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.arbeidsgiver.min_side.controller.SecurityMockMvcUtil.Companion.jwtWithPid
 import no.nav.arbeidsgiver.min_side.models.Organisasjon
 import no.nav.arbeidsgiver.min_side.services.altinn.AltinnService
+import no.nav.arbeidsgiver.min_side.services.ereg.EregService
 import no.nav.arbeidsgiver.min_side.services.tiltak.RefusjonStatusKafkaListener
 import no.nav.arbeidsgiver.min_side.services.tiltak.RefusjonStatusRepository
 import no.nav.arbeidsgiver.min_side.services.tiltak.RefusjonStatusService.Companion.TJENESTEKODE


### PR DESCRIPTION
bruker ~fakedings~ mock-oauth2-server  som external service i stedet for å depende på token support test bibliotek.


TODO:
- [x] fiks service på github actions
fakedings publiseres ikke lenger til åpen registry, og fungerer ikke på github actions.
Snakket med nais og fikk beskjed om å heller bruke mock-oauth-server som en service.
- [x] test io dev
