### PR TITLE
sett resource req og JAVA_OPTS

### DIFF
--- a/nais/dev-env.yaml
+++ b/nais/dev-env.yaml
@@ -38,6 +38,8 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev-gcp
+    - name: JAVA_OPTS
+      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"
   prometheus:
     enabled: true
     path: /ditt-nav-arbeidsgiver-api/internal/actuator/prometheus

--- a/nais/prod-env.yaml
+++ b/nais/prod-env.yaml
@@ -7,6 +7,13 @@ metadata:
     team: fager
 spec:
   image: {{{ image }}}
+  resources:
+    requests:
+      cpu: 400m
+      memory: 512Mi
+    limits:
+      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
+      memory: 1024Mi
   liveness:
     path: /ditt-nav-arbeidsgiver-api/internal/actuator/health
     initialDelay: 90
@@ -39,6 +46,8 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod-gcp
+    - name: JAVA_OPTS
+      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"
   prometheus:
     enabled: true
     path: /ditt-nav-arbeidsgiver-api/internal/actuator/prometheus


### PR DESCRIPTION
dette er samme config som vi bruker i notifikasjonsplatformen.

Litt av bakgrunnen for dette er at vi fikk litt resource exhaustion i perioden 15:00-15:40 i dag pga feil og retries mot api gw og altinn.
Loggene lot vente på seg og CPU bruk var veldig høy. 
Litt usikker på hvorfor det ikke ble skalert opp, men tenker det er lurt å sette samme config slik at vi utnytter podene best mulig.