### PR TITLE
bump spring boot pga CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
In Spring Framework versions 6.0.15 and 6.1.2, it is possible for a user to provide specially crafted HTTP requests that may cause a denial-of-service (DoS) condition.

Specifically, an application is vulnerable when all of the following are true:

the application uses Spring MVC
Spring Security 6.1.6+ or 6.2.1+ is on the classpath
Typically, Spring Boot applications need the org.springframework.boot:spring-boot-starter-web&nbsp;and org.springframework.boot:spring-boot-starter-security&nbsp;dependencies to meet all conditions.

Sonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2024-22233 for details

* https://ossindex.sonatype.org/vulnerability/CVE-2024-22233?component-type=maven&component-name=org.springframework%2Fspring-core&utm_source=dependency-track&utm_medium=integration&utm_content=v4.10.1
* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2024-22233
* https://github.com/spring-projects/spring-framework/issues/31848
* https://spring.io/security/cve-2024-22233/