### PR TITLE
legg til api for kontostatus

### DIFF
--- a/nais/dev-env.yaml
+++ b/nais/dev-env.yaml
@@ -60,3 +60,4 @@ spec:
         - host: tt02.altinn.no
         - host: api-gw-q1.oera.no
         - host: ereg-services.dev-fss-pub.nais.io
+        - host: sokos-kontoregister-q1.dev-fss-pub.nais.io

--- a/nais/dev-env.yaml
+++ b/nais/dev-env.yaml
@@ -48,7 +48,6 @@ spec:
   azure:
     application:
       enabled: true
-      tenant: nav.no
   accessPolicy:
     inbound:
       rules:
@@ -61,4 +60,4 @@ spec:
         - host: tt02.altinn.no
         - host: api-gw-q1.oera.no
         - host: ereg-services.dev-fss-pub.nais.io
-        - host: sokos-kontoregister-q1.dev-fss-pub.nais.io
+        - host: sokos-kontoregister-q2.dev-fss-pub.nais.io

--- a/nais/dev-env.yaml
+++ b/nais/dev-env.yaml
@@ -45,6 +45,9 @@ spec:
     path: /ditt-nav-arbeidsgiver-api/internal/actuator/prometheus
   tokenx:
     enabled: true
+  azure:
+    application:
+      enabled: true
   accessPolicy:
     inbound:
       rules:

--- a/nais/dev-env.yaml
+++ b/nais/dev-env.yaml
@@ -48,6 +48,7 @@ spec:
   azure:
     application:
       enabled: true
+      tenant: nav.no
   accessPolicy:
     inbound:
       rules:

--- a/nais/dev-env.yaml
+++ b/nais/dev-env.yaml
@@ -9,16 +9,8 @@ spec:
   image: {{{ image }}}
   liveness:
     path: /ditt-nav-arbeidsgiver-api/internal/actuator/health
-    initialDelay: 90
-    timeout: 15
-    periodSeconds: 10
-    failureThreshold: 3
   readiness:
     path: /ditt-nav-arbeidsgiver-api/internal/actuator/health
-    initialDelay: 90
-    timeout: 15
-    periodSeconds: 10
-    failureThreshold: 3
   maskinporten:
     enabled: true
     scopes:

--- a/nais/prod-env.yaml
+++ b/nais/prod-env.yaml
@@ -68,3 +68,4 @@ spec:
         - host: www.altinn.no
         - host: api-gw.oera.no
         - host: ereg-services.prod-fss-pub.nais.io
+        - host: sokos-kontoregister.prod-fss-pub.nais.io

--- a/nais/prod-env.yaml
+++ b/nais/prod-env.yaml
@@ -53,6 +53,9 @@ spec:
     path: /ditt-nav-arbeidsgiver-api/internal/actuator/prometheus
   tokenx:
     enabled: true
+  azure:
+    application:
+      enabled: true
   accessPolicy:
     inbound:
       rules:

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/clients/azuread/AzureService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/clients/azuread/AzureService.kt
@@ -18,14 +18,14 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 
 
-private const val maxCachedEntries = 1000L
-private const val cacheExpiryMarginSeconds = 5
 
 @Service
 class AzureService(
     private val azureClient: AzureClient,
     private val azureADProperties: AzureADProperties,
 ) {
+    private val maxCachedEntries = 1000L
+    private val cacheExpiryMarginSeconds = 5
 
     private val cache: Cache<String, AccessTokenEntry> = Caffeine.newBuilder()
         .expireAfter(object : Expiry<String, AccessTokenEntry> {

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/config/AppConfig.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/config/AppConfig.kt
@@ -12,9 +12,7 @@ import org.springframework.boot.web.client.RestTemplateCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpRequest
-import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.*
-import org.springframework.http.HttpStatusCode
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -128,7 +126,7 @@ class AppConfig {
             } finally {
                 log.info(
                     "servlet.response {} {} => {}",
-                    request.method, request.requestURI, HttpStatus.resolve(response.status)
+                    request.method, request.requestURI, resolve(response.status)
                 )
             }
         }
@@ -150,11 +148,3 @@ fun callIdIntercetor(headerName: String = CALL_ID) =
     }
 
 inline fun <reified T : Any> T.logger(): Logger = LoggerFactory.getLogger(this::class.java)
-
-private fun HttpStatusCode.erDriftsforstyrrelse() = when (this) {
-    BAD_GATEWAY,
-    SERVICE_UNAVAILABLE,
-    GATEWAY_TIMEOUT -> true
-
-    else -> false
-}

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontoregisterClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontoregisterClient.kt
@@ -1,0 +1,81 @@
+package no.nav.arbeidsgiver.min_side.kontostatus
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import no.nav.arbeidsgiver.min_side.clients.retryInterceptor
+import no.nav.arbeidsgiver.min_side.config.callIdIntercetor
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClientResponseException
+import java.util.concurrent.TimeUnit
+
+@Component
+class KontoregisterClient(
+    @Value("\${sokos-kontoregister.baseUrl}") sokosKontoregisterBaseUrl: String?,
+    restTemplateBuilder: RestTemplateBuilder
+) {
+    internal val restTemplate = restTemplateBuilder
+        .rootUri(sokosKontoregisterBaseUrl)
+        .additionalInterceptors(
+            callIdIntercetor("nav-call-id"),
+            retryInterceptor(
+                3,
+                250L,
+                org.apache.http.NoHttpResponseException::class.java,
+                java.net.SocketException::class.java,
+                javax.net.ssl.SSLHandshakeException::class.java,
+            )
+        )
+        .build()
+
+    @Cacheable(KONTOREGISTER_CACHE_NAME)
+    fun hentKontonummer(virksomhetsnummer: String): Kontooppslag? {
+        return try {
+            restTemplate.getForEntity(
+                "/kontoregister/api/v1/hent-kontonummer-for-organisasjon/{virksomhetsnummer}",
+                Kontooppslag::class.java,
+                mapOf("virksomhetsnummer" to virksomhetsnummer)
+            ).body
+        } catch (e: RestClientResponseException) {
+            if (e.statusCode == HttpStatus.NOT_FOUND) {
+                return null
+            }
+            throw e
+        }
+    }
+}
+
+/**
+ * ref: https://github.com/navikt/sokos-kontoregister/blob/1ccc9c205a9b4e8f66dbe9c865383b256bcac26b/spec/kontoregister-v1-swagger2.json
+ */
+data class Kontooppslag(
+    /**
+     * Organisasjonsnummer
+     */
+    val mottaker: String,
+    /**
+     * Kontonummer
+     */
+    val kontonr: String,
+)
+
+const val KONTOREGISTER_CACHE_NAME = "kontoregister_cache"
+
+@Configuration
+class KontoregisterCacheConfig {
+
+    @Bean
+    fun kontoregisterCache() = CaffeineCache(
+        KONTOREGISTER_CACHE_NAME,
+        Caffeine.newBuilder()
+            .maximumSize(600000)
+            .expireAfterWrite(30, TimeUnit.MINUTES)
+            .recordStats()
+            .build()
+    )
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontoregisterClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontoregisterClient.kt
@@ -32,7 +32,7 @@ class KontoregisterClient(
                 request.headers.setBearerAuth(
                     azureService.getAccessToken(gittMiljø.resolve(
                         prod = { "prod-fss.okonomi.sokos-kontoregister" },
-                        dev = { "dev-fss.okonomi.sokos-kontoregister" },
+                        dev = { "dev-fss.okonomi.sokos-kontoregister-q2" },
                         other = { " " }
                     ))
                 )

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusController.kt
@@ -1,6 +1,6 @@
 package no.nav.arbeidsgiver.min_side.kontostatus
 
-import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController
 class KontostatusController(
     val kontoregisterClient: KontoregisterClient,
 ) {
-    @GetMapping("/api/kontonummerStatus/v1")
+    @PostMapping("/api/kontonummerStatus/v1")
     fun get(
         @RequestBody body: Request,
     ) = when (kontoregisterClient.hentKontonummer(body.virksomhetsnummer)) {

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusController.kt
@@ -1,0 +1,27 @@
+package no.nav.arbeidsgiver.min_side.kontostatus
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class KontostatusController(
+    val kontoregisterClient: KontoregisterClient,
+) {
+    @GetMapping("/api/kontonummerStatus/v1")
+    fun get(
+        @RequestBody body: Request,
+    ) = when (kontoregisterClient.hentKontonummer(body.virksomhetsnummer)) {
+        null -> Response(KontonummerStatus.MANGLER_KONTONUMMER)
+        else -> Response(KontonummerStatus.OK)
+    }
+
+    data class Request(val virksomhetsnummer: String)
+
+    data class Response(val status: KontonummerStatus)
+
+    enum class KontonummerStatus {
+        OK,
+        MANGLER_KONTONUMMER,
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -119,7 +119,7 @@ altinn:
   apiBaseUrl: "https://tt02.altinn.no"
 
 ereg-services.baseUrl: "https://ereg-services.dev-fss-pub.nais.io"
-sokos-kontoregister.baseUrl: "https://sokos-kontoregister-q1.dev-fss-pub.nais.io"
+sokos-kontoregister.baseUrl: "https://sokos-kontoregister-q2.dev-fss-pub.nais.io"
 
 token.x:
   privateJwk: ${TOKEN_X_PRIVATE_JWK}}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -120,7 +120,7 @@ altinn:
   apiBaseUrl: "https://tt02.altinn.no"
 
 ereg-services.baseUrl: "https://ereg-services.dev-fss-pub.nais.io"
-sokos-kontoregister.baseUrl: "https://sokos-kontoregister.dev-fss-pub.nais.io"
+sokos-kontoregister.baseUrl: "https://sokos-kontoregister-q1.dev-fss-pub.nais.io"
 
 token.x:
   privateJwk: ${TOKEN_X_PRIVATE_JWK}}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,6 +85,7 @@ altinn:
   apiBaseUrl: "http://altinn.example.org"
 
 ereg-services.baseUrl: "https://localhost"
+sokos-kontoregister.baseUrl: "https://localhost"
 
 token.x:
   privateJwk: fake
@@ -113,6 +114,7 @@ altinn:
   apiBaseUrl: "https://tt02.altinn.no"
 
 ereg-services.baseUrl: "https://ereg-services.dev-fss-pub.nais.io"
+sokos-kontoregister.baseUrl: "https://sokos-kontoregister.dev-fss-pub.nais.io"
 
 token.x:
   privateJwk: ${TOKEN_X_PRIVATE_JWK}}
@@ -140,6 +142,7 @@ altinn:
   apiBaseUrl: "https://www.altinn.no"
 
 ereg-services.baseUrl: "https://ereg-services.prod-fss-pub.nais.io"
+sokos-kontoregister.baseUrl: "https://sokos-kontoregister.prod-fss-pub.nais.io"
 
 token.x:
   privateJwk: ${TOKEN_X_PRIVATE_JWK}}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,6 +54,12 @@ springdoc:
     enabled: true
   packagesToScan: no.nav.arbeidsgiver.min_side
 
+azuread:
+  tenantId: ${AZURE_APP_TENANT_ID:}
+  openidTokenEndpoint: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT:}
+  clientId: ${AZURE_APP_CLIENT_ID:}
+  openidIssuer: ${AZURE_OPENID_CONFIG_ISSUER:}
+  jwk: ${AZURE_APP_JWK:}
 
 ---
 
@@ -92,13 +98,6 @@ token.x:
   clientId: fake
   issuer: http://fake
   tokenEndpoint: http://fake/token
-
-azuread:
-  tenantId: ${AZURE_APP_TENANT_ID:}
-  openidTokenEndpoint: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT:}
-  clientId: ${AZURE_APP_CLIENT_ID:}
-  openidIssuer: ${AZURE_OPENID_CONFIG_ISSUER:}
-  jwk: ${AZURE_APP_JWK:}
 
 ---
 spring:

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusTest.kt
@@ -1,0 +1,100 @@
+package no.nav.arbeidsgiver.min_side.kontostatus
+
+import no.nav.arbeidsgiver.min_side.controller.SecurityMockMvcUtil.Companion.jwtWithPid
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpMethod.GET
+import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@SpringBootTest(
+    properties = [
+        "server.servlet.context-path=/",
+        "spring.flyway.cleanDisabled=false",
+    ]
+)
+@AutoConfigureMockMvc
+class KontostatusTest {
+
+    @Autowired
+    lateinit var kontoregisterClient: KontoregisterClient
+
+    lateinit var server: MockRestServiceServer
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun setUp() {
+        server = MockRestServiceServer.bindTo(kontoregisterClient.restTemplate).build()
+    }
+
+
+    @Test
+    fun `henter kontonummer fra kontoregister`() {
+        val virksomhetsnummer = "42"
+        server.expect {
+            requestTo("/kontoregister/api/v1/hent-kontonummer-for-organisasjon/$virksomhetsnummer")
+            method(GET)
+        }.andRespond(
+            withSuccess(
+                """
+                {
+                    "mottaker": "42",
+                    "kontonr": "12345678901"
+                }
+                """,
+                APPLICATION_JSON
+            )
+        )
+
+        kontoregisterClient.hentKontonummer(virksomhetsnummer).let {
+            Assertions.assertEquals("42", it?.mottaker)
+            Assertions.assertEquals("12345678901", it?.kontonr)
+        }
+
+        mockMvc.get("/api/kontonummerStatus/v1") {
+            content = """{"virksomhetsnummer": "$virksomhetsnummer"}"""
+            contentType = APPLICATION_JSON
+            accept = APPLICATION_JSON
+            with(jwtWithPid("42"))
+        }.andExpect {
+            status { isOk() }
+            content { json("""{"status": "OK"}""") }
+        }
+    }
+
+    @Test
+    fun `finner ikke kontonummer for virksomhet`() {
+        val virksomhetsnummer = "123"
+        server.expect {
+            requestTo("/kontoregister/api/v1/hent-kontonummer-for-organisasjon/$virksomhetsnummer")
+            method(GET)
+        }.andRespond(withStatus(NOT_FOUND))
+
+        kontoregisterClient.hentKontonummer(virksomhetsnummer).let {
+            Assertions.assertNull(it)
+        }
+
+        mockMvc.get("/api/kontonummerStatus/v1") {
+            content = """{"virksomhetsnummer": "$virksomhetsnummer"}"""
+            contentType = APPLICATION_JSON
+            accept = APPLICATION_JSON
+            with(jwtWithPid("42"))
+        }.andExpect {
+            status { isOk() }
+            content { json("""{"status": "MANGLER_KONTONUMMER"}""") }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusTest.kt
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.HttpMethod.GET
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.web.client.MockRestServiceServer
 import org.springframework.test.web.client.match.MockRestRequestMatchers.method
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
@@ -21,11 +23,14 @@ import org.springframework.test.web.servlet.get
 @SpringBootTest(
     properties = [
         "server.servlet.context-path=/",
-        "spring.flyway.cleanDisabled=false",
+        "spring.flyway.enabled=false",
     ]
 )
 @AutoConfigureMockMvc
 class KontostatusTest {
+
+    @MockBean // the real jwt decoder is bypassed by SecurityMockMvcRequestPostProcessors.jwt
+    lateinit var jwtDecoder: JwtDecoder
 
     @Autowired
     lateinit var kontoregisterClient: KontoregisterClient

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontostatusTest.kt
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.http.HttpMethod.GET
+import org.springframework.http.HttpMethod.POST
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.oauth2.jwt.JwtDecoder
@@ -19,7 +19,7 @@ import org.springframework.test.web.client.match.MockRestRequestMatchers.request
 import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
 
 @SpringBootTest(
     properties = [
@@ -55,7 +55,7 @@ class KontostatusTest {
         val virksomhetsnummer = "42"
         server.expect {
             requestTo("/kontoregister/api/v1/hent-kontonummer-for-organisasjon/$virksomhetsnummer")
-            method(GET)
+            method(POST)
         }.andRespond(
             withSuccess(
                 """
@@ -73,7 +73,7 @@ class KontostatusTest {
             Assertions.assertEquals("12345678901", it?.kontonr)
         }
 
-        mockMvc.get("/api/kontonummerStatus/v1") {
+        mockMvc.post("/api/kontonummerStatus/v1") {
             content = """{"virksomhetsnummer": "$virksomhetsnummer"}"""
             contentType = APPLICATION_JSON
             accept = APPLICATION_JSON
@@ -89,14 +89,14 @@ class KontostatusTest {
         val virksomhetsnummer = "123"
         server.expect {
             requestTo("/kontoregister/api/v1/hent-kontonummer-for-organisasjon/$virksomhetsnummer")
-            method(GET)
+            method(POST)
         }.andRespond(withStatus(NOT_FOUND))
 
         kontoregisterClient.hentKontonummer(virksomhetsnummer).let {
             Assertions.assertNull(it)
         }
 
-        mockMvc.get("/api/kontonummerStatus/v1") {
+        mockMvc.post("/api/kontonummerStatus/v1") {
             content = """{"virksomhetsnummer": "$virksomhetsnummer"}"""
             contentType = APPLICATION_JSON
             accept = APPLICATION_JSON


### PR DESCRIPTION
følger samme mønster som api for varslingstatus
forutsetter at sokos-kontoregister kan nås fra gcp og at vår klient er autentisert koden her har ikke autentisering med, det må legges til

TODO:
* [x] sokos-kontoregister tilgjengeliggjøres fra fss til gcp
* [x] legg til autentisering (azuread)
  * https://github.com/navikt/min-side-arbeidsgiver-api/pull/366