### PR TITLE
downgrade micrometer to fix IllegalArgumentException after bump of spring boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
         <kotlin.version>2.0.0</kotlin.version>
+
+        <micrometer.version>1.12.6</micrometer.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

error: `j.l.IllegalArgumentException: Counts in ClassicHistogramBuckets cannot be negative.`

refs: https://github.com/micrometer-metrics/micrometer/issues/5193