### PR TITLE
Nærmeste leder uten sykmeldte skal ha tilgang

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/DigisyfoRepository.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/DigisyfoRepository.kt
@@ -145,9 +145,9 @@ class DigisyfoRepositoryImpl(
                 where naermeste_leder_fnr = ?
             ),
             virksomheter as (
-                select distinct s.virksomhetsnummer as virksomhetsnummer
-                from sykmelding as s
-                join nl_koblinger nl on
+                select distinct nl.virksomhetsnummer as virksomhetsnummer
+                from nl_koblinger as nl
+                left outer join sykmelding s on
                     nl.virksomhetsnummer = s.virksomhetsnummer and
                     nl.ansatt_fnr = s.ansatt_fnr
             ),

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/DigisyfoRepositoryImplTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/DigisyfoRepositoryImplTest.kt
@@ -47,7 +47,7 @@ class DigisyfoRepositoryImplTest {
             ),
         )
 
-        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr2 to 0))
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0, vnr2 to 0))
     }
 
     @Test
@@ -64,7 +64,7 @@ class DigisyfoRepositoryImplTest {
             ),
         )
 
-        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr2 to 1))
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0, vnr2 to 1))
     }
 
     @Test
@@ -80,7 +80,7 @@ class DigisyfoRepositoryImplTest {
             ),
         )
 
-        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf())
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0))
     }
 
     @Test
@@ -114,7 +114,20 @@ class DigisyfoRepositoryImplTest {
             ),
         )
 
-        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr2 to 0, vnr3 to 1))
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0, vnr2 to 0, vnr3 to 1))
+    }
+
+    @Test
+    fun `tilgang som nærmeste leder uten sykmeldte`() {
+        val lookup = prepareDatabaseSingletonBatches(
+            today = "2022-06-01",
+            nærmasteLedere = listOf(
+                NL(uuid1, leder1, ansatt1, vnr1),
+            ),
+            sykmeldinger = listOf(),
+        )
+
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0))
     }
 
     @Test
@@ -130,7 +143,7 @@ class DigisyfoRepositoryImplTest {
             ),
         )
 
-        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf())
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0))
         Assertions.assertThat(lookup(leder2)).containsExactlyEntriesOf(mapOf(vnr2 to 1))
     }
 
@@ -147,7 +160,7 @@ class DigisyfoRepositoryImplTest {
             ),
         )
 
-        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf())
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0))
         Assertions.assertThat(lookup(leder2)).containsExactlyEntriesOf(mapOf(vnr2 to 1))
     }
 
@@ -215,7 +228,7 @@ class DigisyfoRepositoryImplTest {
             ),
         )
 
-        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf())
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0))
     }
 
     @Test
@@ -232,7 +245,7 @@ class DigisyfoRepositoryImplTest {
             ),
         )
 
-        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr2 to 1))
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0, vnr2 to 1))
     }
 
     @Test
@@ -266,7 +279,7 @@ class DigisyfoRepositoryImplTest {
             ),
         )
 
-        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr2 to 1))
+        Assertions.assertThat(lookup(leder1)).containsExactlyEntriesOf(mapOf(vnr1 to 0, vnr2 to 1))
     }
 
 


### PR DESCRIPTION
Fiks for [FAGSYSTEM-381368](https://jira.adeo.no/browse/FAGSYSTEM-381368)

Dagens logikk viste kun virksomhet dersom det var eller hadde vært en aktiv sykmelding på virksomheten for nærmeste leder. I følge FAGSYSTEM saken forventes det at man skal ha tilgang uavhengig av aktive sykmeldinger. Med denne endringen vil alle virksomheter nærmeste leder er registrert i gi tilgang uavhengig av sykmeldinger.

Endringen må dobbeltsjekkes med team-sykmelding.