### PR TITLE
Litt mer forklarende oppsett av resttemplate interceptors og servlet …

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/config/RestTemplateConfig.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/config/RestTemplateConfig.kt
@@ -1,0 +1,90 @@
+package no.nav.arbeidsgiver.min_side.config
+
+import no.nav.arbeidsgiver.min_side.config.RestTemplateConfig.Companion.log
+import org.slf4j.Logger
+import org.slf4j.MDC
+import org.slf4j.event.Level
+import org.springframework.boot.web.client.RestTemplateCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpRequest
+import org.springframework.http.HttpStatus.*
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.web.client.RestTemplate
+
+
+/**
+ * Beans av typen [RestTemplateCustomizer] blir automatisk registrert i [RestTemplateBuilder], vha [org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration.restTemplateBuilderConfigurer].
+ * og er dermed tilgjengelig for alle [RestTemplate] som opprettes i applikasjonen. Dette er en type automagi vi gjerne vil skrive oss ut av.
+ * Som et steg på veien så er de samlet og dokumentert her.
+ */
+@Configuration
+class RestTemplateConfig {
+
+    /**
+     * propagerer callid fra MDC til request header
+     */
+    @Bean
+    fun callIdRestTemplateCustomizer() = RestTemplateCustomizer { restTemplate: RestTemplate ->
+        restTemplate.interceptors.add(callIdInterceptor())
+    }
+
+    /**
+     * log basic info om request response via resttemplate
+     */
+    @Bean
+    fun loggingInterceptorCustomizer() = RestTemplateCustomizer { restTemplate: RestTemplate ->
+        restTemplate.interceptors.add(loggingInterceptor())
+    }
+
+    companion object {
+        val log: Logger = logger()
+    }
+}
+
+fun loggingInterceptor(): ClientHttpRequestInterceptor =
+    ClientHttpRequestInterceptor { request: HttpRequest, body: ByteArray?, execution: ClientHttpRequestExecution ->
+        log.info("RestTemplate.request: {} {}{}", request.method, request.uri.host, request.uri.path)
+        val response = execution.execute(request, body!!)
+        log.atLevel(
+            when {
+                response.statusCode in setOf(
+                    NOT_FOUND,
+                    BAD_GATEWAY,
+                    SERVICE_UNAVAILABLE,
+                    GATEWAY_TIMEOUT,
+                ) ->
+                    Level.INFO
+
+                response.statusCode.isError ->
+                    Level.ERROR
+
+                else ->
+                    Level.INFO
+            }
+        ).log(
+            "RestTemplate.response: {} Content-Length: {} for request {} {}{}",
+            when {
+                response.statusCode.isError ->
+                    "${response.statusCode} ${response.statusText}"
+
+                else ->
+                    response.statusCode
+            },
+            response.headers.contentLength,
+            request.method,
+            request.uri.host,
+            request.uri.path
+        )
+        response
+    }
+
+fun callIdInterceptor(headerName: String = CALL_ID) =
+    ClientHttpRequestInterceptor { request: HttpRequest, body: ByteArray?, execution: ClientHttpRequestExecution ->
+        MDC.get(CALL_ID)?.let {
+            request.headers.addIfAbsent(headerName, it)
+        }
+        execution.execute(request, body!!)
+    }
+

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/config/SecurityConfig.kt
@@ -22,7 +22,7 @@ class SecurityConfig {
         // Kotlin DSL requires import org.springframework.security.config.annotation.web.invoke
         http {
             oauth2ResourceServer { jwt { } }
-            authorizeRequests {
+            authorizeHttpRequests {
                 authorize("/internal/actuator/**", permitAll)
                 authorize("/api/**", authenticated)
                 authorize(anyRequest, denyAll)

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontaktinfo/KontaktinfoClient.kt
@@ -13,7 +13,6 @@ import org.springframework.http.HttpMethod.GET
 import org.springframework.stereotype.Component
 import java.net.SocketException
 import javax.net.ssl.SSLHandshakeException
-import kotlin.collections.List
 
 @Component
 class KontaktinfoClient(

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontoregisterClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/kontostatus/KontoregisterClient.kt
@@ -3,7 +3,7 @@ package no.nav.arbeidsgiver.min_side.kontostatus
 import com.github.benmanes.caffeine.cache.Caffeine
 import no.nav.arbeidsgiver.min_side.azuread.AzureService
 import no.nav.arbeidsgiver.min_side.config.GittMiljø
-import no.nav.arbeidsgiver.min_side.config.callIdIntercetor
+import no.nav.arbeidsgiver.min_side.config.callIdInterceptor
 import no.nav.arbeidsgiver.min_side.config.retryInterceptor
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -12,7 +12,6 @@ import org.springframework.cache.caffeine.CaffeineCache
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
-import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClientResponseException
 import java.net.SocketException
@@ -29,8 +28,9 @@ class KontoregisterClient(
     internal val restTemplate = restTemplateBuilder
         .rootUri(sokosKontoregisterBaseUrl)
         .additionalInterceptors(
-            callIdIntercetor("nav-call-id"),
-            ClientHttpRequestInterceptor { request, body, execution ->
+            callIdInterceptor("nav-call-id"),
+
+            { request, body, execution ->
                 request.headers.setBearerAuth(
                     azureService.getAccessToken(gittMiljø.resolve(
                         prod = { "api://prod-fss.okonomi.sokos-kontoregister/.default" },
@@ -40,6 +40,7 @@ class KontoregisterClient(
                 )
                 execution.execute(request, body)
             },
+
             retryInterceptor(
                 3,
                 250L,

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/services/ereg/EregService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/services/ereg/EregService.kt
@@ -2,7 +2,7 @@ package no.nav.arbeidsgiver.min_side.services.ereg
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.github.benmanes.caffeine.cache.Caffeine
-import no.nav.arbeidsgiver.min_side.config.callIdIntercetor
+import no.nav.arbeidsgiver.min_side.config.callIdInterceptor
 import no.nav.arbeidsgiver.min_side.config.retryInterceptor
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -26,7 +26,7 @@ class EregService(
     internal val restTemplate = restTemplateBuilder
         .rootUri(eregBaseUrl)
         .additionalInterceptors(
-            callIdIntercetor("Nav-Call-Id"),
+            callIdInterceptor("Nav-Call-Id"),
             retryInterceptor(
                 3,
                 250L,


### PR DESCRIPTION
…filter

Vi diskutrete i teamet og snakket om at vi gjerne skulle kommet oss bort fra spring automagi. Ser ut som det ikke er så lett når det gjelder servlet filterne. Man kan wire de på flere måter, men ingen av disse virket veldig mye mer eksplisitt. Når det gjelder resttemplate så er denne endringen et steg på veien. Vi kan som neste steg koble fra RestTemplateCustomizer beans og heller sette disse eksplisitt alle steder vi bygger en resttemplate