### PR TITLE
Team logs take 2

### DIFF
--- a/nais/dev-env.yaml
+++ b/nais/dev-env.yaml
@@ -60,6 +60,8 @@ spec:
     outbound:
       rules:
         - application: arbeidsgiver-altinn-tilganger
+        - application: logging
+          namespace: nais-system
       external:
         - host: platform.tt02.altinn.no
         - host: tt02.altinn.no

--- a/nais/prod-env.yaml
+++ b/nais/prod-env.yaml
@@ -60,6 +60,8 @@ spec:
     outbound:
       rules:
         - application: arbeidsgiver-altinn-tilganger
+        - application: logging
+          namespace: nais-system
       external:
         - host: platform.altinn.no
         - host: www.altinn.no

--- a/specifications/team_logging.md
+++ b/specifications/team_logging.md
@@ -390,7 +390,3 @@ Place it next to the existing `log.info(...)` startup lines (search for
 | `nais/prod-env.yaml` | Add `logging.nais-system` outbound rule |
 
 No `pom.xml` change.
-
-## Important Update
-
-Team logs was causing connection issues and memory leaks ending with OOMKilled in production. It is now removed until we can find a better solution for tracing without risking stability.

--- a/specifications/team_logging.md
+++ b/specifications/team_logging.md
@@ -1,4 +1,4 @@
-# Team logging for Kafka consumers and userInfo
+# Team logging for Kafka consumers and userInfo (v2)
 
 ## 1. Goal
 
@@ -9,28 +9,67 @@ claim their accesses are wrong. Specifically:
   stream, gated behind an SLF4J `Marker`. Anything logged with that marker goes
   to `team-logs` only and is excluded from the regular logs (and the other way
   around).
-- From every Kafka consumer in `MsaKafkaConsumer.kt`, emit a team-log line per
-  processed record with enough detail (topic, partition, offset, key, raw
-  value) to reproduce what the consumer saw.
-- From `UserInfoService.getUserInfoV3`, emit a team-log line per call with the
-  resolved user identity and the full response payload that was returned to the
-  caller, so we can correlate "user reports their access list is wrong" with
-  what we actually computed.
+- From every Kafka consumer in `MsaKafkaConsumer.kt`, emit a team-log line
+  **on processing failure** with the full record (topic, partition, offset,
+  key, raw value) so we can reproduce what the consumer saw. Do **not** emit a
+  team-log line per successful record.
+- From `UserInfoService.getUserInfoV3`, emit a team-log summary line on every
+  call (counts + error flags), and the full `UserInfoV3` JSON payload only when
+  `altinnError || digisyfoError`.
 
-The team-log infrastructure must be a faithful copy of
+The team-log infrastructure is a port of
 [`Logging.kt`](../../arbeidsgiver-altinn-tilganger/src/main/kotlin/no/nav/fager/infrastruktur/Logging.kt)
-in `arbeidsgiver-altinn-tilganger`, including the explicit `MarkerLogger`, the
-`MaskingAppender`, and the per-line character-truncation regex on the
-`team-logs` encoder.
+in `arbeidsgiver-altinn-tilganger`, with explicit hardening on the
+`LogstashTcpSocketAppender` (bounded ring buffer, non-blocking append,
+non-spinning wait strategy, longer reconnection delay) because v1 fell over.
+
+## 1.1 History: why this is v2
+
+v1 of this spec shipped in
+[PR #429](https://github.com/navikt/min-side-arbeidsgiver-api/pull/429) and
+was reverted in
+[PR #430](https://github.com/navikt/min-side-arbeidsgiver-api/pull/430)
+because of:
+
+- **Memory pressure that looked like a leak.** Every Kafka record was logged
+  to team-logs with the full raw `value`. With six consumers (some on
+  high-volume Sykefravær topics) and the default `LogstashTcpSocketAppender`
+  ring buffer of 8 192 slots, each slot retains the `ILoggingEvent` (which in
+  turn retains every argument). When the TCP destination stalled or got slow,
+  the ring buffer filled and held many MB of `String` payloads — heap climbed,
+  pods went OOM. Not a true leak, but the effect was the same.
+- **Connection-error spam.** `team-logs.nais-system:5170` is shared
+  infrastructure and is not always reachable. The appender's reconnect loop
+  produced a steady stream of `java.net.ConnectException` / `SocketException`
+  lines, which is noisy and (worse) feeds back into the same logger context.
+
+NAIS' team-logs documentation
+([nais.io › observability › logging › team-logs](https://doc.nais.io/observability/logging/how-to/team-logs/))
+confirms the TCP appender to `team-logs.nais-system:5170` is the only
+supported transport — there is no stdout-based alternative. So v2 keeps the
+transport and fixes the application-side mistakes:
+
+1. **Bound the in-process queue and never block the caller.** Smaller ring
+   buffer, `appendTimeout = 0`, non-spinning `waitStrategyType` → drop on
+   overflow instead of growing the heap, never stall a Kafka poll or HTTP
+   handler waiting on the log socket.
+2. **Cut the event volume at the source.** Successful Kafka records produce
+   nothing on team-logs. `userInfo` produces a small summary on every call
+   and the full payload only when something went wrong.
+3. **Tame reconnect spam.** Longer reconnection delay, an explicit
+   `StatusListener` so logback's internal status output doesn't flood stdout.
+
+Everything else from v1 (marker filter, `MarkerLogger`, `MaskingAppender` on
+the console stream only, character-truncation regex, `TeamLogTest`) is kept
+as-is.
 
 ## 2. Why a separate team-logs stream
 
 Loki/the default stdout stream is for ops. It is sampled, indexed, and shared
 broadly. `team-logs` is a separate destination managed by NAIS, retained
 shorter, scoped to the team, and is the right place to put payloads with
-end-user content (org numbers, access strings, fnr-shaped data after masking).
-Mixing the two would either pollute ops dashboards or leak more than ops is
-allowed to see.
+end-user content (org numbers, access strings, fnr). Mixing the two would
+either pollute ops dashboards or leak more than ops is allowed to see.
 
 The separation is enforced at the appender level by an SLF4J `Marker`
 (`TEAM_LOGS`):
@@ -43,350 +82,358 @@ A `MarkerLogger` wrapper guarantees that every call made through `teamLogger()`
 attaches the marker — direct `marker` arguments are explicitly forbidden so it
 is not possible to accidentally bypass the filter.
 
-**Masking is asymmetric and intentional.** In the source `Logging.kt` the
-`MaskingAppender` wraps only the `ConsoleAppender`; the `LogstashTcpSocketAppender`
-to `team-logs.nais-system:5170` is added directly to the root logger and is
-**not** wrapped. Team-logs therefore receives raw, unmasked content. This is
-exactly what we want here: the whole reason we are setting team-logs up is to
-investigate "this user got the wrong accesses" tickets, and that investigation
-needs the actual fnr / org numbers / access strings. The masking on stdout
-prevents the same content from leaking into ops/Loki. Do not add masking to
-the team-logs appender.
+**Masking is asymmetric and intentional.** The `MaskingAppender` wraps only
+the `ConsoleAppender`; the `LogstashTcpSocketAppender` is added to the root
+logger directly and is **not** wrapped. Team-logs receives raw, unmasked
+content — the whole reason we are setting it up is to investigate
+"this user got the wrong accesses" tickets, which needs the actual fnr / org
+numbers / access strings. Do not add masking to the team-logs appender.
 
-## 3. Current state
+## 3. Current state (post-revert, pre-v2 changes)
 
-- `src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt` is a
-  one-liner that exposes `inline fun <reified T : Any> T.logger()`.
-- `src/main/resources/logback.xml` declares a `ConsoleAppender` with
-  `LogstashEncoder` and an inline `MaskingJsonGeneratorDecorator` that masks
-  11- and 9-digit sequences.
-- There is no `META-INF/services/ch.qos.logback.classic.spi.Configurator` and
-  no team-logs destination.
-- `Miljø.clusterName` already reads `NAIS_CLUSTER_NAME` and falls back to
-  `"local"`. There is also `Miljø.resolve(prod, dev, other)`.
-- `pom.xml` already has `slf4j-api 2.0.12`, `logback-classic 1.5.22`,
-  `logstash-logback-encoder 8.1` — same versions as the source repo. **No new
-  dependencies are required.**
-- Existing call sites that use `logger()`:
-  - [`MsaKafkaConsumer.kt:35`](../src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/MsaKafkaConsumer.kt)
-  - [`AltinnTilgangSoknadService.kt:11`](../src/main/kotlin/no/nav/arbeidsgiver/min_side/tilgangssoknad/AltinnTilgangSoknadService.kt)
+The revert of PR #430 put the v1 implementation back on the branch. As of
+`HEAD` on `revert-430-rm_team_logs`:
 
-These call sites must keep working unchanged — `logger()` keeps the same
-signature.
+- `src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt`
+  contains the full v1 port (`LogConfig`, `MaskingAppender`, `teamLogger()`,
+  `MarkerLogger`). The `LogstashTcpSocketAppender` uses **defaults** for ring
+  buffer, append timeout, wait strategy, and reconnection delay — those are
+  the v2 hardening targets.
+- `src/main/resources/META-INF/services/ch.qos.logback.classic.spi.Configurator`
+  exists and points at `LogConfig`. `logback.xml` is gone.
+- `MsaKafkaConsumer.kt` logs a team-log line per record in both `consume(...)`
+  and `batchConsume(...)`, **including on the success path**. This is the
+  volume problem; v2 removes the success-path logs.
+- `UserInfoService.kt` always logs the full `UserInfoV3` JSON payload to
+  team-logs. v2 changes this to summary-always, full-on-error.
+- `nais/dev-env.yaml` and `nais/prod-env.yaml` already have
+  `logging.nais-system` in `accessPolicy.outbound.rules`.
+- `Application.kt` already emits `teamLogger().info("Team logging enabled")`
+  at startup.
+- `src/test/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/TeamLogTest.kt`
+  is in place and passing.
+
+So v2 is a focused change — three files, two distinct concerns (TCP appender
+hardening + event volume reduction).
 
 ## 4. Deliverables
 
-### 4.1 Replace `infrastruktur/Logging.kt`
+### 4.1 Harden the `LogstashTcpSocketAppender` in `Logging.kt`
 
-Path: `src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt`
+File: `src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt`
 
-Port the entire contents of
-`arbeidsgiver-altinn-tilganger/src/main/kotlin/no/nav/fager/infrastruktur/Logging.kt`,
-adjusting only what is necessary to fit this codebase. Specifically:
+Inside `LogConfig.configure`, on the `LogstashTcpSocketAppender().setup(lc) { ... }`
+block, set the following properties **in addition to** what is there today.
+Do not change anything else in the file (the masking, marker filter, custom
+fields, and truncation pattern are correct).
 
-1. Change the package declaration to
-   `no.nav.arbeidsgiver.min_side.infrastruktur`.
-2. Replace `import no.nav.fager.infrastruktur.NaisEnvironment.clusterName`
-   with the existing `Miljø.clusterName` from this project. The `LogConfig`
-   should read `Miljø.clusterName.isNotEmpty() && Miljø.clusterName != "local"`
-   to decide whether to attach the team-logs TCP appender (the source repo
-   uses `clusterName.isNotEmpty()`; we use the stricter check because our
-   fallback is `"local"`, not `""`).
-3. Replace the `basedOnEnv(prod = ..., dev = ..., other = ...)` call inside
-   `LogConfig.configure` with the equivalent `Miljø.resolve(prod = { ... },
-   dev = { ... }, other = { ... })` already in this project. For now keep all
-   three branches at `Level.INFO`, matching the source.
-4. Keep the existing `inline fun <reified T : Any> T.logger(): Logger` so the
-   two existing call sites compile unchanged. The source repo's variant uses
-   `T::class.qualifiedName` while ours uses `this::class.java`. **Keep our
-   current form** to avoid silently changing logger names on existing call
-   sites; only add `teamLogger()` and the rest as new API.
-5. Port verbatim:
-   - `const val TEAM_LOGS = "TEAM_LOGS"`
-   - `val TEAM_LOG_MARKER: Marker = MarkerFactory.getMarker(TEAM_LOGS)`
-   - `class LogConfig : ContextAwareBase(), Configurator` including the two
-     filters (console DENY when marker present, TCP ACCEPT only when marker
-     present), the custom-fields JSON, and the
-     `LoggingEventPatternJsonProvider` whose pattern is
-     `{"message":"%replace(%message){'^(.{125000}).+$', '$1...truncated'}"}`.
-     This is the per-line character-truncation regex called out in the brief
-     and must be preserved exactly — `team-logs` rejects oversized lines, so
-     truncation must happen client-side before the line leaves the pod.
-   - `private fun <T> T.setup(...)` extension.
-   - `class MaskingAppender` with the four regexes (`FNR`, `ORGNR`, `EPOST`,
-     `PASSWORD`) and the `mask(...)` companion. It wraps the
-     `ConsoleAppender` only (i.e. `MaskingAppender { appender = ConsoleAppender { ... } }`).
-     The `LogstashTcpSocketAppender` for team-logs is added to the root
-     logger directly and remains unmasked — preserve this asymmetry exactly.
-   - `inline fun <reified T> T.teamLogger(): Logger`.
-   - `class MarkerLogger(val logger: Logger, val marker: Marker) : Logger` in
-     full — including all the `directMarkerUsageNotAllowed()` overrides. Do
-     not abridge it; the whole point of this class is that it is exhaustive.
+```kotlin
+addAppender(LogstashTcpSocketAppender().setup(lc) {
+    this.name = "TEAMLOGS"
+    addDestination("team-logs.nais-system:5170")
 
-Do **not** keep the `MaskingJsonGeneratorDecorator`-based masking from the
-current `logback.xml`. The new `MaskingAppender` replaces it for both streams.
+    // --- v2 hardening: bound the queue, never block the caller ---
+    this.ringBufferSize = 1024                                                          // default 8192
+    this.appendTimeout = ch.qos.logback.core.util.Duration.buildByMilliseconds(0.0)     // drop on full instead of blocking
+    setWaitStrategyType("sleeping")                                                     // method (no getter → no synthetic property); no busy spin
+    this.reconnectionDelay = ch.qos.logback.core.util.Duration.buildByMinutes(1.0)      // default 30s
+    this.keepAliveDuration = ch.qos.logback.core.util.Duration.buildByMinutes(5.0)      // keep socket warm
+    // --- end v2 hardening ---
 
-### 4.2 Register the configurator
-
-Create `src/main/resources/META-INF/services/ch.qos.logback.classic.spi.Configurator`
-with the single line:
-
-```
-no.nav.arbeidsgiver.min_side.infrastruktur.LogConfig
+    this.encoder = LogstashEncoder().setup(lc) {
+        // ... existing customFields, isIncludeContext = false,
+        //     LoggingEventPatternJsonProvider truncation pattern unchanged ...
+    }
+    addFilter(...)  // existing ACCEPT-on-marker filter unchanged
+})
 ```
 
-### 4.3 Remove `src/main/resources/logback.xml`
+Notes on the API (logstash-logback-encoder 8.1):
 
-Logback uses XML config in preference to a `Configurator` SPI when both are
-present, so the file must be deleted (not just emptied) for `LogConfig` to
-take effect. Also remove `logback-test.xml` if any test variant exists (none
-currently does — verify).
+- `ringBufferSize` is a power-of-two `Int` on `AsyncDisruptorAppender`. 1024 ×
+  worst-case ~50 KB per event = ~50 MB retained at full backpressure — well
+  inside our 1 GiB pod limit.
+- `appendTimeout` expects `ch.qos.logback.core.util.Duration` (logback's
+  type, **not** `java.time.Duration`). There is no `Duration.ZERO` constant;
+  use `Duration.buildByMilliseconds(0.0)`. A zero-millisecond timeout means
+  "do not wait if the ring buffer is full, drop the event and return
+  immediately." This is the load-bearing fix — it guarantees that a stalled
+  team-logs destination cannot block a Kafka poll loop or an HTTP handler.
+- `waitStrategyType` is exposed as `setWaitStrategyType(String)` only — no
+  matching getter, so Kotlin does **not** synthesise a property. Call the
+  setter as a method: `setWaitStrategyType("sleeping")`. Valid values
+  include `"blocking"`, `"sleeping"`, `"yielding"`, `"busySpin"`,
+  `"phasedBackoff{...}"`. We pick `"sleeping"` because it does not burn
+  CPU when there is nothing to consume.
+- `reconnectionDelay` and `keepAliveDuration` also use logback's
+  `ch.qos.logback.core.util.Duration`. They do have matching getters, so
+  the Kotlin property assignment works. Use the `buildBy*` factory methods
+  to avoid relying on the string parser.
 
-### 4.4 Update both NAIS manifests
+### 4.2 Status listener to quiet logback's own connection-error spam
 
-Both `nais/dev-env.yaml` and `nais/prod-env.yaml` need:
+File: `src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt`
 
-- Under `accessPolicy.outbound.rules`, add:
-  ```yaml
-  - application: logging
-    namespace: nais-system
-  ```
-  Without this, the TCP socket to `team-logs.nais-system:5170` is blocked by
-  network policy and the appender silently drops events.
+Add this at the top of `LogConfig.configure(lc)`, before any appender is
+created:
 
-- Leave `observability.logging.destinations: [loki]` as-is. The team-logs
-  stream is established via the direct TCP appender, not via the NAIS logging
-  destinations list.
+```kotlin
+override fun configure(lc: LoggerContext): ExecutionStatus {
+    // Suppress repeated transport-error status messages from the TCP appender.
+    // Without this, logback's StatusManager prints a connection error to
+    // stderr on every failed reconnect, which is noisy and (in v1) appeared
+    // in pod logs as a slow drip even when team-logs was just briefly down.
+    lc.statusManager.add(RateLimitedStatusListener(maxMessagesPerMinute = 6))
 
-No changes to `prometheus`, `tokenx`, `azure`, `kafka`, or other sections.
+    // ... existing rootAppender / addAppender code unchanged ...
+}
+```
 
-### 4.5 Kafka consumer team logging
+And add the class to the same file (alongside `MaskingAppender`):
+
+```kotlin
+/**
+ * StatusListener that rate-limits status messages to N per minute.
+ *
+ * Used to silence the reconnect-error storm from LogstashTcpSocketAppender
+ * when team-logs.nais-system is briefly unreachable. Without this, every
+ * reconnect attempt produces a Status WARN/ERROR that the StatusManager
+ * prints to stderr.
+ */
+class RateLimitedStatusListener(
+    private val maxMessagesPerMinute: Int,
+) : ch.qos.logback.core.status.StatusListener,
+    ch.qos.logback.core.spi.LifeCycle {
+
+    private val window = java.time.Duration.ofMinutes(1)
+    private val timestamps = java.util.ArrayDeque<java.time.Instant>()
+    private var started = false
+
+    override fun addStatusEvent(status: ch.qos.logback.core.status.Status) {
+        // Only rate-limit WARN/ERROR; let INFO through (they are rare, mostly startup).
+        if (status.level < ch.qos.logback.core.status.Status.WARN) {
+            System.err.println(status)
+            return
+        }
+        val now = java.time.Instant.now()
+        synchronized(timestamps) {
+            while (timestamps.isNotEmpty() && java.time.Duration.between(timestamps.peekFirst(), now) > window) {
+                timestamps.pollFirst()
+            }
+            if (timestamps.size < maxMessagesPerMinute) {
+                timestamps.addLast(now)
+                System.err.println(status)
+            }
+            // else: drop silently
+        }
+    }
+
+    override fun start() { started = true }
+    override fun stop() { started = false }
+    override fun isStarted(): Boolean = started
+}
+```
+
+This is enough. We could go further (e.g. count drops and emit a "suppressed
+N messages" summary), but the bar is "do not flood pod stdout with reconnect
+exceptions", which six lines/minute satisfies.
+
+### 4.3 Kafka consumer: log on error only
 
 File: `src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/MsaKafkaConsumer.kt`
 
-Add a class-level team logger alongside the existing one:
+**Remove** the per-record team-log lines on the success path in both
+`consume(...)` and `batchConsume(...)` — the `record.also { teamLog.info(...) }`
+blocks. **Add** the team-log call inside the existing `catch (e: Exception)`
+branch instead.
 
-```kotlin
-private val log = logger()
-private val teamLog = teamLogger()
-```
-
-For each record processed in `consume(...)` and `batchConsume(...)`, emit a
-single `INFO`-level team-log line per record, **before** delegating to
-`processor.processRecord(...)` / `processor.processRecords(...)`. The line
-must include:
-
-- topic
-- partition
-- offset
-- timestamp (`record.timestamp()`)
-- key (string, may be `null`)
-- value (raw string, may be `null` for tombstones)
-- consumer group id (from `config.groupId`)
-
-Use a structured-friendly format that survives JSON encoding intact. Prefer
-the `.also { teamLog.info(...) }` form to keep the call site terse — apply it
-inside the existing per-record loop in `consume(...)`:
+`consume(...)` shape after the change:
 
 ```kotlin
 for (record in records) {
-    record.also {
-        teamLog.info(
-            "kafka record received groupId={} topic={} partition={} offset={} timestamp={} key={} value={}",
-            config.groupId, it.topic(), it.partition(), it.offset(),
-            it.timestamp(), it.key(), it.value()
-        )
-    }
     try {
         processor.processRecord(record)
     } catch (e: Exception) {
-        // ... existing error handling unchanged ...
+        teamLog.error(
+            "kafka record failed groupId={} topic={} partition={} offset={} timestamp={} key={} value={}",
+            config.groupId, record.topic(), record.partition(), record.offset(),
+            record.timestamp(), record.key(), record.value(), e
+        )
+        log.error("Feil ved prosessering av kafka-melding.", e)
+
+        // without seek next poll will advance the offset, regardless of autocommit=false
+        consumer.seek(TopicPartition(record.topic(), record.partition()), record.offset())
+
+        throw Exception("Feil ved prosessering av kafka-melding. partition=${record.partition()} offset=${record.offset()} $config", e)
     }
 }
 ```
 
-In `batchConsume`, log per record inside a `for (record in records) { ... }`
-loop **before** calling `processor.processRecords(records)` (do not log a
-single batch summary instead of per-record lines — we need per-record
-granularity to debug "this specific event was skipped"). Same `.also { ... }`
-form.
+`batchConsume(...)` shape: the existing failure path catches once per batch,
+not per record — we don't know which record in the batch was the culprit. Log
+every record in the batch on failure so the support case has the full
+context. (Errors are rare; a batch of, say, 500 records logged once on a real
+failure is fine.)
 
-Keep the existing `log.info(...)` lines (subscribed, polled count, committing
-offsets) untouched — they go to ops/Loki and are useful in their own right.
-Keep `log.error(...)` on failure paths untouched. Do **not** mirror the error
-to team logs unless the original record content would otherwise be lost; the
-per-record team log already captures the input that triggered the failure.
+```kotlin
+try {
+    processor.processRecords(records)
+} catch (e: Exception) {
+    for (record in records) {
+        teamLog.error(
+            "kafka record failed (batch) groupId={} topic={} partition={} offset={} timestamp={} key={} value={}",
+            config.groupId, record.topic(), record.partition(), record.offset(),
+            record.timestamp(), record.key(), record.value()
+        )
+    }
+    log.error("Feil ved prosessering av kafka-melding.", e)
 
-Note: team-logs is unmasked, so the raw `value` (and any org numbers it
-contains) lands in team-logs as-is. That is the point — we want to be able
-to reproduce exactly what the consumer saw. The same record never reaches
-stdout/Loki, so the unmasked content does not leak into ops.
+    for (tp in records.partitions()) {
+        consumer.seek(tp, records.records(tp).first().offset())
+    }
 
-### 4.6 UserInfo team logging
+    throw Exception("Feil ved prosessering av kafka-melding. $config", e)
+}
+```
+
+Pass the exception only to the first `teamLog.error` call (or just the
+`log.error`), not on every per-record team-log line — repeating the stack
+trace per record is wasteful.
+
+The existing `log.info(...)` lines (subscribed, polled count, committing
+offsets) stay untouched; they remain on stdout/Loki for ops.
+
+### 4.4 UserInfo: summary always, full payload on error only
 
 File: `src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoService.kt`
 
-Add a class-level team logger and emit one team-log line per
-`getUserInfoV3(...)` call, on the result of `UserInfoV3.from(...)`. Use
-`.also { teamLog.info(...) }` chained on the constructor call so the return
-expression stays a single statement. The line must include:
-
-- `fnr` (the input — logged raw; team-logs is unmasked by design and we want
-  to be able to grep team-logs by fnr when a user reports their accesses are
-  wrong)
-- `altinnError`, `digisyfoError` flags
-- the full `UserInfoV3` payload, JSON-encoded via `defaultJson` — this gives
-  us `tilganger`, `organisasjoner` (each `AltinnTilgang`), `digisyfoOrganisasjoner`
-  and `refusjoner` in one shot, in exactly the shape the caller received
-
-Implementation sketch:
+Replace the single `teamLog.info(... payload=...)` inside the `.also { ... }`
+with a two-step pattern: always log the small summary, log the full payload
+only when one of the error flags is set.
 
 ```kotlin
-private val teamLog = teamLogger()
-
 suspend fun getUserInfoV3(fnr: String, token: String) = supervisorScope {
-    // ... existing async/await ...
+    val tilganger = async { runCatching { altinnTilgangerService.hentAltinnTilganger(token) } }
+    val syfoVirksomheter = async { runCatching { digisyfoService.hentVirksomheterOgSykmeldte(fnr) } }
+    val refusjoner = async { runCatching { refusjonStatusService.statusoversikt(token) } }
+
     UserInfoV3.from(tilganger.await(), syfoVirksomheter.await(), refusjoner.await())
-        .also {
+        .also { result ->
             teamLog.info(
-                "userInfo response fnr={} altinnError={} digisyfoError={} payload={}",
-                fnr, it.altinnError, it.digisyfoError,
-                defaultJson.encodeToString(UserInfoV3.serializer(), it)
+                "userInfo summary fnr={} altinnError={} digisyfoError={} orgCount={} digisyfoOrgCount={} refusjonCount={} tilgangCount={}",
+                fnr, result.altinnError, result.digisyfoError,
+                result.organisasjoner.size, result.digisyfoOrganisasjoner.size,
+                result.refusjoner.size, result.tilganger.size
             )
+            if (result.altinnError || result.digisyfoError) {
+                teamLog.info(
+                    "userInfo payload (errored) fnr={} payload={}",
+                    fnr,
+                    defaultJson.encodeToString(UserInfoV3.serializer(), result)
+                )
+            }
         }
 }
 ```
 
-Use `defaultJson` from
-`no.nav.arbeidsgiver.min_side.infrastruktur.SerDes` (the same instance the
-rest of the project uses). All three of `AltinnTilgang`, `VirksomhetOgAntallSykmeldte`,
-and `Statusoversikt` are already `@Serializable` because `UserInfoV3` is
-serialized as the HTTP response.
+Rationale:
 
-Log on the success path only — failures already surface as `altinnError`/
-`digisyfoError` flags inside the payload, which is the information ops cares
-about. Do not log inside the `runCatching { ... }` blocks; those have already
-been folded into the result by the time we want to log.
+- The summary line is small (well under 1 KB) and goes on every call. It
+  gives us a per-user heartbeat in team-logs: "did this user even hit the
+  endpoint, and what did the counts look like."
+- The full payload only fires when at least one upstream failed
+  (`altinnError` or `digisyfoError`), which is the case where a support
+  ticket is plausible anyway. In healthy operation we ship zero full
+  payloads, so the byte cost is bounded by the summary line × QPS.
+- We deliberately do **not** add a random-sample full-payload log (e.g.
+  "1 in 100 successful calls"). If support needs to debug a successful call
+  whose contents look wrong to the user, we can re-add sampling — but right
+  now the summary is enough to confirm "we returned N orgs" and the user's
+  actual access set lives upstream in Altinn anyway.
 
-The 125 000-character truncation regex on the team-logs encoder protects us
-from a pathological response with thousands of orgs blowing up team-logs
-ingestion. We rely on it; do not add another truncation in code.
+### 4.5 No changes to v1 deliverables that are already merged
 
-### 4.7 Port `TeamLogTest`
+The following are already on the branch in their v1 form and need **no
+modification**:
 
-Path: `src/test/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/TeamLogTest.kt`
-
-Copy
-[`TeamLogTest.kt`](../../arbeidsgiver-altinn-tilganger/src/test/kotlin/no/nav/fager/infrastruktur/TeamLogTest.kt)
-verbatim, changing only the `package` declaration to
-`no.nav.arbeidsgiver.min_side.infrastruktur`. Keep all three tests:
-
-1. `vanlig logg skal ikke inneholde verdier i teamLog` — captures stdout while
-   logging one ordinary line and one team-log line, asserts the ordinary line
-   appears on stdout and the team-log line does not. **This is the
-   load-bearing test**: if it fails, the marker filter on the `ConsoleAppender`
-   has been broken and team-log content is leaking into ops/Loki. The KDoc on
-   the test already says as much; keep the comment.
-2. `logging av placeholders, mdc og exceptions fungerer som normalt` — sanity
-   check that placeholder substitution, MDC, and exception logging still work
-   on the regular logger after the configurator rewrite.
-3. `logging av object som arg fungerer` — the `MarkerLogger` overrides
-   varargs methods carefully; this guards against a regression where passing
-   an object as the SLF4J argument throws.
-
-The private `captureStdout` helper is part of the file — copy it as-is. The
-test relies on the configurator being picked up via the SPI file (4.2), so
-a passing test also implicitly verifies the META-INF wiring.
-
-### 4.8 Application startup line (optional, recommended)
-
-In `Application.kt`, after the logger is initialised on startup, emit a
-single line:
-
-```kotlin
-teamLogger().info("Team logging enabled")
-```
-
-This mirrors what `arbeidsgiver-altinn-tilganger` does and gives us a positive
-signal in `team-logs` per pod start so we can confirm the pipeline is live.
-Place it next to the existing `log.info(...)` startup lines (search for
-`Application.kt` for an analogous spot).
+- `META-INF/services/ch.qos.logback.classic.spi.Configurator`
+- The `logback.xml` deletion
+- `nais/dev-env.yaml` and `nais/prod-env.yaml` outbound rule
+  (`logging.nais-system`)
+- `Application.kt` `Team logging enabled` startup line
+- `TeamLogTest.kt`
+- The `MaskingAppender` four-regex masking (plus the `FNR_SPACE` pattern and
+  the MDC masking that landed in PR #432 — keep both)
 
 ## 5. Acceptance criteria
 
-1. `mvn -q package` succeeds, including the new `TeamLogTest`. No new compiler
-   warnings introduced by `MarkerLogger`'s `@Deprecated`/`Marker?` overrides
-   (these are expected and present in the source repo).
-2. Existing unit and integration tests pass. The two existing `logger()` call
-   sites compile unchanged.
-3. Boot the app locally with `NAIS_CLUSTER_NAME` unset. Log lines on stdout
-   are JSON and masked (11- and 9-digit sequences redacted on the **stdout**
-   stream). The `team-logs.nais-system:5170` socket is **not** opened (verify
-   in `LogConfig` that the TCP appender is conditional on `clusterName`).
-4. Boot the app locally with `NAIS_CLUSTER_NAME=dev-gcp` (or in dev). The
-   stdout stream contains all the existing `log.info(...)` lines and **none**
-   of the new `teamLog.info(...)` lines. The team-logs stream (visible in the
-   NAIS logging UI / Grafana team-logs board for the `fager` team) contains
-   the new per-Kafka-record lines and the per-userInfo-call payload, with
-   org numbers and fnrs intact (unmasked).
-5. A request to `GET /api/userInfo/v3` produces exactly one new line in
-   team-logs per call, containing `payload=` with the full JSON shape.
-6. A Kafka record on any of the six configured topics produces exactly one
-   new line in team-logs.
-7. The 11-digit string `12345678901` appearing in a regular `log.info(...)`
-   call comes out as `***********` on stdout. The same string passed through
-   `teamLog.info(...)` appears unmasked in team-logs. (The `TeamLogTest`
-   covers the routing half of this — the masking half can be eyeballed in a
-   dev pod.)
+1. `mvn -q package` succeeds. `TeamLogTest` still passes — the marker filter
+   is unchanged. No new compiler warnings beyond the expected `MarkerLogger`
+   ones.
+2. A `GET /api/userInfo/v3` against a healthy backend produces **one** team-log
+   line ending in `userInfo summary fnr=... orgCount=...` and **zero** lines
+   with `payload=`.
+3. The same endpoint against a backend where `AltinnTilgangerService` is
+   forced to fail (or returns `isError = true`) produces **one** summary line
+   and **one** `userInfo payload (errored)` line containing the JSON.
+4. Driving Kafka traffic on any topic produces **zero** team-log lines per
+   successful record. Making `processRecord(...)` throw produces **one**
+   `kafka record failed ...` team-log line per failed record, with the raw
+   `value` intact (unmasked).
+5. In dev, with `team-logs.nais-system` reachable, the new lines appear in
+   the team-logs index for the `fager` team and stdout is silent.
+6. In dev, with team-logs deliberately blocked (temporarily remove the
+   `logging.nais-system` outbound rule, deploy, then put it back), pod
+   memory stays under ~512 MiB during sustained Kafka traffic — confirming
+   the bounded ring buffer + dropping appender. Reconnect-error lines on
+   stderr stay under a handful per minute, confirming the status listener.
+7. Sanity check the truncation: emit a `teamLog.info(...)` with a > 125 000
+   character argument. The line that lands in team-logs ends in
+   `...truncated"` (the JSON-encoded truncation pattern from the encoder).
+
+Criteria 6 and 7 are nice-to-have manual verifications during the next dev
+deploy; they are the failure-mode regression tests for v1's two problems.
 
 ## 6. Out of scope
 
-- Adding team-logs lines to non-Kafka, non-userInfo code paths (Altinn HTTP
-  client, Ereg, Refusjon HTTP, etc.). If a future support case needs them,
-  add them in a follow-up.
-- Changing log levels per package. Everything stays at `INFO`.
-- Sampling or rate-limiting. The 125 000-char per-line truncation is the only
-  guard for now.
-- Replacing `Miljø.clusterName` with a separate `NaisEnvironment` object.
-  We reuse what the project already has.
-- Migrating other masking patterns (e.g. JWT tokens). The four patterns from
-  the source repo (`FNR`, `ORGNR`, `EPOST`, `PASSWORD`) are sufficient and
-  match what we mask today.
+- Adding team-logs lines to non-Kafka, non-userInfo code paths.
+- Random-sample full-payload userInfo logs. We will reconsider if support
+  needs them.
+- A Micrometer gauge for ring-buffer fill ratio. Useful follow-up if we want
+  early warning of pressure before drops start; not required for v2.
+- Tuning `writeBufferSize`, `writeTimeout`, or the TCP keep-alive socket
+  options below the JVM defaults. The Logback defaults are fine once the
+  application-side queue is bounded.
 
 ## 7. Risks and mitigations
 
-- **Risk: team-logs TCP socket fills up on backpressure.** Logback's
-  `LogstashTcpSocketAppender` has bounded ring buffers and drops on overflow
-  by default — acceptable for debug logs. No code change needed.
-- **Risk: team-logs is unmasked, so fnr and org numbers land in team-logs raw.**
-  This is intentional — debugging a "wrong accesses" case requires the actual
-  identifiers — and team-logs is a team-scoped destination with appropriate
-  access controls. The marker-based filter on the `ConsoleAppender` keeps the
-  same content off stdout/Loki. The `TeamLogTest` is the regression test that
-  guards this boundary; if it ever starts failing, treat it as a sensitive-data
-  leak and stop the deploy.
-- **Risk: `logback.xml` removal accidentally drops the existing masking and
-  the new `LogConfig` is not picked up** (e.g. the META-INF service file is
-  misnamed). Mitigation: as part of acceptance, boot locally and grep stdout
-  for `***********` in a known fnr-shaped string. If the masking is gone,
-  `LogConfig` did not load — most likely the SPI file path is wrong.
-- **Risk: logger names change for the two existing `logger()` call sites and
-  break log-based alerts.** Mitigation: keep the `this::class.java`
-  implementation rather than adopting the source repo's
-  `T::class.qualifiedName`. The logger name stays exactly what it is today.
+- **Risk: we still drop events under sustained backpressure.** Yes — that is
+  the point. Team-logs is a debug-only stream; losing some lines is
+  preferable to OOMing the pod or stalling Kafka. The error-path Kafka log
+  and the userInfo error-path payload log are the only "important" lines,
+  and they are emitted from contexts where errors are already rare.
+- **Risk: the `appendTimeout = Duration.ZERO` semantics differ between
+  versions of logstash-logback-encoder.** As of 8.1 (which we use),
+  `Duration.ZERO` documents as "do not wait." If a future upgrade changes
+  this, the ring-buffer-full test (criterion 6) will catch it — but the
+  failure mode would be "Kafka throughput drops" not "memory leak", so it
+  is monitorable.
+- **Risk: rate-limited status listener swallows a useful diagnostic.** Cap
+  is 6/minute on WARN+. A genuinely broken transport will still produce
+  multiple lines per minute for as long as it is broken; we won't miss it.
+  INFO-level status events (mainly the lifecycle messages on boot) are not
+  rate-limited.
+- **Risk: team-logs is unmasked.** Unchanged from v1. The marker filter on
+  `ConsoleAppender` keeps the same content off stdout/Loki. `TeamLogTest` is
+  the regression test.
 
-## 8. Files touched (summary)
+## 8. Files touched (v2 only)
 
 | Path | Change |
 | --- | --- |
-| `src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt` | Replace with ported version |
-| `src/main/resources/META-INF/services/ch.qos.logback.classic.spi.Configurator` | New, one line |
-| `src/main/resources/logback.xml` | Delete |
-| `src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/MsaKafkaConsumer.kt` | Add `teamLog`, per-record team-log line in both consume loops |
-| `src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoService.kt` | Add `teamLog`, log full response payload via `.also { ... }` on the `UserInfoV3.from(...)` result |
-| `src/test/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/TeamLogTest.kt` | New, ported verbatim from `arbeidsgiver-altinn-tilganger` (package change only) |
-| `src/main/kotlin/no/nav/arbeidsgiver/min_side/Application.kt` | Add `teamLogger().info("Team logging enabled")` on startup |
-| `nais/dev-env.yaml` | Add `logging.nais-system` outbound rule |
-| `nais/prod-env.yaml` | Add `logging.nais-system` outbound rule |
+| `src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt` | Add `ringBufferSize`, `appendTimeout`, `waitStrategyType`, `reconnectionDelay`, `keepAliveDuration` on the TCP appender. Add `RateLimitedStatusListener` class and register it on the `LoggerContext`. |
+| `src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/MsaKafkaConsumer.kt` | Remove per-record success-path `teamLog.info(...)` in both `consume` and `batchConsume`. Add `teamLog.error(...)` inside the existing failure paths (per-record in `consume`, per-record-in-batch in `batchConsume`). |
+| `src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoService.kt` | Replace single `teamLog.info` with summary line on every call + full-payload line only when `altinnError || digisyfoError`. |
 
-No `pom.xml` change.
+No NAIS manifest changes, no `pom.xml` change, no new files. Existing
+`TeamLogTest` continues to cover the marker-routing invariant.

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/Application.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/Application.kt
@@ -67,6 +67,7 @@ fun main() {
             shutdownTimeout = 30_000
         }
     ) {
+        teamLogger().info("Team logging enabled")
         ktorConfig()
         configureDependencies()
         configureTokenXAuth()

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt
@@ -9,33 +9,77 @@ import ch.qos.logback.classic.spi.IThrowableProxy
 import ch.qos.logback.core.Appender
 import ch.qos.logback.core.AppenderBase
 import ch.qos.logback.core.ConsoleAppender
+import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.ContextAware
 import ch.qos.logback.core.spi.ContextAwareBase
+import ch.qos.logback.core.spi.FilterReply
 import ch.qos.logback.core.spi.LifeCycle
+import net.logstash.logback.appender.LogstashTcpSocketAppender
+import net.logstash.logback.composite.loggingevent.LoggingEventPatternJsonProvider
 import net.logstash.logback.encoder.LogstashEncoder
 import org.slf4j.Logger
 import org.slf4j.Logger.ROOT_LOGGER_NAME
 import org.slf4j.LoggerFactory
 import org.slf4j.Marker
+import org.slf4j.MarkerFactory
+import org.slf4j.spi.LoggingEventBuilder
 import java.time.Instant
+
+const val TEAM_LOGS = "TEAM_LOGS"
+val TEAM_LOG_MARKER: Marker = MarkerFactory.getMarker(TEAM_LOGS)
 
 /* used by resources/META-INF/services/ch.qos.logback.classic.spi */
 class LogConfig : ContextAwareBase(), Configurator {
 
     override fun configure(lc: LoggerContext): ExecutionStatus {
+        val rootAppender = MaskingAppender().setup(lc) {
+            appender = ConsoleAppender<ILoggingEvent>().setup(lc) {
+                encoder = LogstashEncoder().setup(lc) {
+                    isIncludeMdc = true
+                }
+                addFilter(object : Filter<ILoggingEvent>() {
+                    override fun decide(event: ILoggingEvent) = when {
+                        (event.markerList ?: emptyList()).contains(TEAM_LOG_MARKER) -> FilterReply.DENY
+                        else -> FilterReply.NEUTRAL
+                    }
+                })
+            }
+        }
+
         lc.getLogger(ROOT_LOGGER_NAME).apply {
             level = Miljø.resolve(
                 prod = { Level.INFO },
                 dev = { Level.INFO },
                 other = { Level.INFO }
             )
-            addAppender(MaskingAppender().setup(lc) {
-                appender = ConsoleAppender<ILoggingEvent>().setup(lc) {
+            addAppender(rootAppender)
+
+            val clusterName = Miljø.clusterName
+            if (clusterName.isNotEmpty() && clusterName != "local") {
+                addAppender(LogstashTcpSocketAppender().setup(lc) {
+                    this.name = "TEAMLOGS"
+                    addDestination("team-logs.nais-system:5170")
                     this.encoder = LogstashEncoder().setup(lc) {
-                        this.isIncludeMdc = true
+                        this.customFields = """{
+                        |"google_cloud_project":"${System.getenv("GOOGLE_CLOUD_PROJECT")}",
+                        |"nais_namespace_name":"${System.getenv("NAIS_NAMESPACE")}",
+                        |"nais_pod_name":"${System.getenv("NAIS_POD_NAME")}",
+                        |"nais_container_name":"${System.getenv("NAIS_APP_NAME")}"
+                        |}""".trimMargin()
+                        this.isIncludeContext = false
+                        addProvider(LoggingEventPatternJsonProvider().apply {
+                            this.pattern =
+                                """{"message":"%replace(%message){'^(.{125000}).+$', '$1...truncated'}"}"""
+                        })
                     }
-                }
-            })
+                    addFilter(object : Filter<ILoggingEvent>() {
+                        override fun decide(event: ILoggingEvent) = when {
+                            (event.markerList ?: emptyList()).contains(TEAM_LOG_MARKER) -> FilterReply.ACCEPT
+                            else -> FilterReply.DENY
+                        }
+                    })
+                })
+            }
         }
 
 
@@ -109,3 +153,108 @@ class MaskingAppender : AppenderBase<ILoggingEvent>() {
 }
 
 inline fun <reified T : Any> T.logger(): Logger = LoggerFactory.getLogger(this::class.java)
+inline fun <reified T> T.teamLogger(): Logger = MarkerLogger(LoggerFactory.getLogger(T::class.qualifiedName), TEAM_LOG_MARKER)
+
+/**
+ * Logger wrapper that enforces usage of a specific Marker for all logging methods.
+ * Prevents direct use of Marker arguments in logging methods.
+ *
+ * Useful to ensure TeamLog marker is guaranteed when using teamLogger().
+ */
+class MarkerLogger(
+    val logger: Logger,
+    val marker: Marker
+) : Logger {
+
+
+    /**
+     * proxy logging methods with marker
+     */
+
+    override fun trace(msg: String?) = logger.trace(marker, msg)
+    override fun trace(format: String?, arg: Any?) = logger.trace(marker, format, arg)
+    override fun trace(format: String?, arg1: Any?, arg2: Any?) = logger.trace(marker, format, arg1, arg2)
+    override fun trace(format: String?, vararg arguments: Any?) = logger.trace(marker, format, *arguments)
+    override fun trace(msg: String?, t: Throwable?) = logger.trace(marker, msg, t)
+    override fun debug(msg: String?) = logger.debug(marker, msg)
+    override fun debug(format: String?, arg: Any?) = logger.debug(marker, format, arg)
+    override fun debug(format: String?, arg1: Any?, arg2: Any?) = logger.debug(marker, format, arg1, arg2)
+    override fun debug(format: String?, vararg arguments: Any?) = logger.debug(marker, format, *arguments)
+    override fun debug(msg: String?, t: Throwable?) = logger.debug(marker, msg, t)
+    override fun info(msg: String?) = logger.info(marker, msg)
+    override fun info(format: String?, arg: Any?) = logger.info(marker, format, arg)
+    override fun info(format: String?, arg1: Any?, arg2: Any?) = logger.info(marker, format, arg1, arg2)
+    override fun info(format: String?, vararg arguments: Any?) = logger.info(marker, format, *arguments)
+    override fun info(msg: String?, t: Throwable?) = logger.info(marker, msg, t)
+    override fun warn(msg: String?) = logger.warn(marker, msg)
+    override fun warn(format: String?, arg: Any?) = logger.warn(marker, format, arg)
+    override fun warn(format: String?, vararg arguments: Any?) = logger.warn(marker, format, *arguments)
+    override fun warn(format: String?, arg1: Any?, arg2: Any?) = logger.warn(marker, format, arg1, arg2)
+    override fun warn(msg: String?, t: Throwable?) = logger.warn(marker, msg, t)
+    override fun error(msg: String?) = logger.error(marker, msg)
+    override fun error(format: String?, arg: Any?) = logger.error(marker, format, arg)
+    override fun error(format: String?, arg1: Any?, arg2: Any?) = logger.error(marker, format, arg1, arg2)
+    override fun error(format: String?, vararg arguments: Any?) = logger.error(marker, format, *arguments)
+    override fun error(msg: String?, t: Throwable?) = logger.error(marker, msg, t)
+
+
+    /**
+     * prevent direct marker usage
+     */
+
+    override fun isTraceEnabled(marker: Marker?): Boolean = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, format: String?, vararg argArray: Any?) = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    override fun isDebugEnabled(marker: Marker?): Boolean = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, format: String?, vararg arguments: Any?) = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    override fun isInfoEnabled(marker: Marker?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, format: String?, vararg arguments: Any?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    override fun isWarnEnabled(marker: Marker?): Boolean = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, format: String?, vararg arguments: Any?) = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    override fun isErrorEnabled(marker: Marker?): Boolean = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, format: String?, vararg arguments: Any?) = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    private fun directMarkerUsageNotAllowed(): Nothing =
+        throw UnsupportedOperationException("Direct use of Marker arg in MarkerLogger is not allowed")
+
+
+    /**
+     * override default methods, not overriden by delegation "by logger"
+     */
+
+    override fun makeLoggingEventBuilder(level: org.slf4j.event.Level?): LoggingEventBuilder? =
+        logger.makeLoggingEventBuilder(level)
+
+    override fun atLevel(level: org.slf4j.event.Level?): LoggingEventBuilder? = logger.atLevel(level)
+    override fun atTrace(): LoggingEventBuilder? = logger.atTrace()
+    override fun isEnabledForLevel(level: org.slf4j.event.Level?): Boolean = logger.isEnabledForLevel(level)
+    override fun atDebug(): LoggingEventBuilder? = logger.atDebug()
+    override fun atInfo(): LoggingEventBuilder? = logger.atInfo()
+    override fun atWarn(): LoggingEventBuilder? = logger.atWarn()
+    override fun atError(): LoggingEventBuilder? = logger.atError()
+
+    override fun isTraceEnabled(): Boolean = logger.isTraceEnabled
+    override fun isDebugEnabled(): Boolean = logger.isDebugEnabled
+    override fun isInfoEnabled(): Boolean = logger.isInfoEnabled
+    override fun isWarnEnabled(): Boolean = logger.isWarnEnabled
+    override fun isErrorEnabled(): Boolean = logger.isErrorEnabled
+    override fun getName(): String? = logger.name
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/Logging.kt
@@ -32,6 +32,12 @@ val TEAM_LOG_MARKER: Marker = MarkerFactory.getMarker(TEAM_LOGS)
 class LogConfig : ContextAwareBase(), Configurator {
 
     override fun configure(lc: LoggerContext): ExecutionStatus {
+        // Suppress repeated transport-error status messages from the TCP appender.
+        // Without this, logback's StatusManager prints a connection error to
+        // stderr on every failed reconnect, which is noisy and (in v1) appeared
+        // in pod logs as a slow drip even when team-logs was just briefly down.
+        lc.statusManager.add(RateLimitedStatusListener(maxMessagesPerMinute = 6))
+
         val rootAppender = MaskingAppender().setup(lc) {
             appender = ConsoleAppender<ILoggingEvent>().setup(lc) {
                 encoder = LogstashEncoder().setup(lc) {
@@ -59,6 +65,15 @@ class LogConfig : ContextAwareBase(), Configurator {
                 addAppender(LogstashTcpSocketAppender().setup(lc) {
                     this.name = "TEAMLOGS"
                     addDestination("team-logs.nais-system:5170")
+
+                    // --- v2 hardening: bound the queue, never block the caller ---
+                    this.ringBufferSize = 1024
+                    this.appendTimeout = ch.qos.logback.core.util.Duration.buildByMilliseconds(0.0)
+                    setWaitStrategyType("sleeping")
+                    this.reconnectionDelay = ch.qos.logback.core.util.Duration.buildByMinutes(1.0)
+                    this.keepAliveDuration = ch.qos.logback.core.util.Duration.buildByMinutes(5.0)
+                    // --- end v2 hardening ---
+
                     this.encoder = LogstashEncoder().setup(lc) {
                         this.customFields = """{
                         |"google_cloud_project":"${System.getenv("GOOGLE_CLOUD_PROJECT")}",
@@ -154,6 +169,47 @@ class MaskingAppender : AppenderBase<ILoggingEvent>() {
 
 inline fun <reified T : Any> T.logger(): Logger = LoggerFactory.getLogger(this::class.java)
 inline fun <reified T> T.teamLogger(): Logger = MarkerLogger(LoggerFactory.getLogger(T::class.qualifiedName), TEAM_LOG_MARKER)
+
+/**
+ * StatusListener that rate-limits status messages to N per minute.
+ *
+ * Used to silence the reconnect-error storm from LogstashTcpSocketAppender
+ * when team-logs.nais-system is briefly unreachable. Without this, every
+ * reconnect attempt produces a Status WARN/ERROR that the StatusManager
+ * prints to stderr.
+ */
+class RateLimitedStatusListener(
+    private val maxMessagesPerMinute: Int,
+) : ch.qos.logback.core.status.StatusListener,
+    ch.qos.logback.core.spi.LifeCycle {
+
+    private val window = java.time.Duration.ofMinutes(1)
+    private val timestamps = java.util.ArrayDeque<java.time.Instant>()
+    private var started = false
+
+    override fun addStatusEvent(status: ch.qos.logback.core.status.Status) {
+        // Only rate-limit WARN/ERROR; let INFO through (they are rare, mostly startup).
+        if (status.level < ch.qos.logback.core.status.Status.WARN) {
+            System.err.println(status)
+            return
+        }
+        val now = java.time.Instant.now()
+        synchronized(timestamps) {
+            while (timestamps.isNotEmpty() && java.time.Duration.between(timestamps.peekFirst(), now) > window) {
+                timestamps.pollFirst()
+            }
+            if (timestamps.size < maxMessagesPerMinute) {
+                timestamps.addLast(now)
+                System.err.println(status)
+            }
+            // else: drop silently
+        }
+    }
+
+    override fun start() { started = true }
+    override fun stop() { started = false }
+    override fun isStarted(): Boolean = started
+}
 
 /**
  * Logger wrapper that enforces usage of a specific Marker for all logging methods.

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/MsaKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/MsaKafkaConsumer.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.*
 import no.nav.arbeidsgiver.min_side.infrastruktur.defaultJson
 import no.nav.arbeidsgiver.min_side.infrastruktur.isActiveAndNotTerminating
 import no.nav.arbeidsgiver.min_side.infrastruktur.logger
+import no.nav.arbeidsgiver.min_side.infrastruktur.teamLogger
 import no.nav.arbeidsgiver.min_side.services.tiltak.RefusjonStatusRepository
 import no.nav.arbeidsgiver.min_side.sykefravarstatistikk.MetadataVirksomhetKafkaKeyDto
 import no.nav.arbeidsgiver.min_side.sykefravarstatistikk.StatistikkategoriKafkaKeyDto
@@ -23,7 +24,6 @@ import org.apache.kafka.common.serialization.StringDeserializer
 import java.lang.System.getenv
 import java.time.LocalDateTime
 import java.util.*
-import kotlin.time.Duration.Companion.milliseconds
 
 data class KafkaConsumerConfig(
     val topics: Set<String>,
@@ -34,6 +34,7 @@ class MsaKafkaConsumer(
     private val config: KafkaConsumerConfig,
 ) {
     private val log = logger()
+    private val teamLog = teamLogger()
 
     private val properties = Properties().apply {
         put(ConsumerConfig.GROUP_ID_CONFIG, config.groupId)
@@ -66,6 +67,13 @@ class MsaKafkaConsumer(
 
                     if (records.any()) {
                         for (record in records) {
+                            record.also {
+                                teamLog.info(
+                                    "kafka record received groupId={} topic={} partition={} offset={} timestamp={} key={} value={}",
+                                    config.groupId, it.topic(), it.partition(), it.offset(),
+                                    it.timestamp(), it.key(), it.value()
+                                )
+                            }
                             try {
                                 processor.processRecord(record)
                             } catch (e: Exception) {
@@ -84,7 +92,7 @@ class MsaKafkaConsumer(
                     throw e
                 } catch (e: Exception) {
                     log.error("Feil ved prosessering av kafka-melding. $config", e)
-                    delay(5000.milliseconds)
+                    delay(5000)
                 }
             }
         }
@@ -101,6 +109,15 @@ class MsaKafkaConsumer(
                     log.info("polled {} records {}", records.count(), config)
 
                     if (records.any()) {
+                        for (record in records) {
+                            record.also {
+                                teamLog.info(
+                                    "kafka record received groupId={} topic={} partition={} offset={} timestamp={} key={} value={}",
+                                    config.groupId, it.topic(), it.partition(), it.offset(),
+                                    it.timestamp(), it.key(), it.value()
+                                )
+                            }
+                        }
                         try {
                             processor.processRecords(records)
                         } catch (e: Exception) {
@@ -120,7 +137,7 @@ class MsaKafkaConsumer(
                     throw e
                 } catch (e: Exception) {
                     log.error("Feil ved prosessering av kafka-melding. $config", e)
-                    delay(5000.milliseconds)
+                    delay(5000)
                 }
             }
         }

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/MsaKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/services/digisyfo/MsaKafkaConsumer.kt
@@ -67,16 +67,14 @@ class MsaKafkaConsumer(
 
                     if (records.any()) {
                         for (record in records) {
-                            record.also {
-                                teamLog.info(
-                                    "kafka record received groupId={} topic={} partition={} offset={} timestamp={} key={} value={}",
-                                    config.groupId, it.topic(), it.partition(), it.offset(),
-                                    it.timestamp(), it.key(), it.value()
-                                )
-                            }
                             try {
                                 processor.processRecord(record)
                             } catch (e: Exception) {
+                                teamLog.error(
+                                    "kafka record failed groupId={} topic={} partition={} offset={} timestamp={} key={} value={}",
+                                    config.groupId, record.topic(), record.partition(), record.offset(),
+                                    record.timestamp(), record.key(), record.value(), e
+                                )
                                 log.error("Feil ved prosessering av kafka-melding.", e)
 
                                 // without seek next poll will advance the offset, regardless of autocommit=false
@@ -109,18 +107,16 @@ class MsaKafkaConsumer(
                     log.info("polled {} records {}", records.count(), config)
 
                     if (records.any()) {
-                        for (record in records) {
-                            record.also {
-                                teamLog.info(
-                                    "kafka record received groupId={} topic={} partition={} offset={} timestamp={} key={} value={}",
-                                    config.groupId, it.topic(), it.partition(), it.offset(),
-                                    it.timestamp(), it.key(), it.value()
-                                )
-                            }
-                        }
                         try {
                             processor.processRecords(records)
                         } catch (e: Exception) {
+                            for (record in records) {
+                                teamLog.error(
+                                    "kafka record failed (batch) groupId={} topic={} partition={} offset={} timestamp={} key={} value={}",
+                                    config.groupId, record.topic(), record.partition(), record.offset(),
+                                    record.timestamp(), record.key(), record.value()
+                                )
+                            }
                             log.error("Feil ved prosessering av kafka-melding.", e)
 
                             // without seek next poll will advance the offset, regardless of autocommit=false

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoService.kt
@@ -3,6 +3,8 @@ package no.nav.arbeidsgiver.min_side.userinfo
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
 import kotlinx.serialization.Serializable
+import no.nav.arbeidsgiver.min_side.infrastruktur.defaultJson
+import no.nav.arbeidsgiver.min_side.infrastruktur.teamLogger
 import no.nav.arbeidsgiver.min_side.services.altinn.AltinnTilganger
 import no.nav.arbeidsgiver.min_side.services.altinn.AltinnTilgangerService
 import no.nav.arbeidsgiver.min_side.services.digisyfo.DigisyfoService
@@ -13,6 +15,7 @@ class UserInfoService(
     private val digisyfoService: DigisyfoService,
     private val refusjonStatusService: RefusjonStatusService,
 ) {
+    private val teamLog = teamLogger()
 
     suspend fun getUserInfoV3(fnr: String, token: String) = supervisorScope {
         val tilganger = async {
@@ -32,6 +35,13 @@ class UserInfoService(
             }
         }
         UserInfoV3.from(tilganger.await(), syfoVirksomheter.await(), refusjoner.await())
+            .also {
+                teamLog.info(
+                    "userInfo response fnr={} altinnError={} digisyfoError={} payload={}",
+                    fnr, it.altinnError, it.digisyfoError,
+                    defaultJson.encodeToString(UserInfoV3.serializer(), it)
+                )
+            }
     }
 }
 

--- a/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/min_side/userinfo/UserInfoService.kt
@@ -35,12 +35,20 @@ class UserInfoService(
             }
         }
         UserInfoV3.from(tilganger.await(), syfoVirksomheter.await(), refusjoner.await())
-            .also {
+            .also { result ->
                 teamLog.info(
-                    "userInfo response fnr={} altinnError={} digisyfoError={} payload={}",
-                    fnr, it.altinnError, it.digisyfoError,
-                    defaultJson.encodeToString(UserInfoV3.serializer(), it)
+                    "userInfo summary fnr={} altinnError={} digisyfoError={} orgCount={} digisyfoOrgCount={} refusjonCount={} tilgangCount={}",
+                    fnr, result.altinnError, result.digisyfoError,
+                    result.organisasjoner.size, result.digisyfoOrganisasjoner.size,
+                    result.refusjoner.size, result.tilganger.size
                 )
+                if (result.altinnError || result.digisyfoError) {
+                    teamLog.info(
+                        "userInfo payload (errored) fnr={} payload={}",
+                        fnr,
+                        defaultJson.encodeToString(UserInfoV3.serializer(), result)
+                    )
+                }
             }
     }
 }

--- a/src/test/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/TeamLogTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/min_side/infrastruktur/TeamLogTest.kt
@@ -1,0 +1,75 @@
+package no.nav.arbeidsgiver.min_side.infrastruktur
+
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.slf4j.MDC
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TeamLogTest {
+
+    /**
+     * Dersom denne testen feiler så er [LogConfig] blitt feilkonfigurert slik at
+     * sensitive data kan lekke i loggene.
+     */
+    @Test
+    fun `vanlig logg skal ikke inneholde verdier i teamLog`() {
+        val log = logger()
+        val teamLog = teamLogger()
+        val stdout = captureStdout {
+            log.info("FOO")
+            teamLog.info("BAR")
+        }
+
+        assertTrue(stdout.contains("FOO"), "forventet å finne vanlig logg-melding")
+        assertFalse(stdout.contains("BAR"), "forventet å ikke finne team logg-melding")
+    }
+
+    @Test
+    fun `logging av placeholders, mdc og exceptions fungerer som normalt`() {
+        val log = logger()
+        val mdcCtx = mapOf("secret" to "shhh")
+        val ex = RuntimeException("oh noes, more lemmings")
+        val stdout = captureStdout {
+            MDC.setContextMap(mdcCtx)
+            log.warn("FOO {} {}", "bar", "baz", ex)
+            MDC.clear()
+        }
+
+        assertTrue(stdout.contains("FOO"))
+        assertTrue(stdout.contains("bar"))
+        assertTrue(stdout.contains("baz"))
+        assertTrue(stdout.contains(ex.message!!))
+        for (arg in mdcCtx) {
+            assertTrue(stdout.contains(arg.key))
+            assertTrue(stdout.contains(arg.value))
+        }
+    }
+
+    @Test
+    fun `logging av object som arg fungerer`() {
+        val teamLog = teamLogger()
+
+        assertDoesNotThrow {
+            teamLog.error("tester logging av object {}", mapOf("key" to "value"))
+        }
+    }
+
+}
+
+private fun captureStdout(block: () -> Unit): String {
+    val originalOut = System.out
+    val captured = try {
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        val printStream = PrintStream(byteArrayOutputStream, true)
+        System.setOut(printStream)
+        block()
+        byteArrayOutputStream.toString()
+    } finally {
+        System.setOut(originalOut)
+    }
+    print(captured)
+    return captured
+}


### PR DESCRIPTION
Reverts navikt/min-side-arbeidsgiver-api#430

Team-logs v2: harden TCP appender, rate-limit status listener, log errors only
- TCP appender: ringBuffer=1024, appendTimeout=0ms, sleeping wait strategy
- RateLimitedStatusListener: max 6 WARN/ERROR per minute to suppress reconnect spam
- MsaKafkaConsumer: remove per-record success logging, add error-path teamLog.error
- UserInfoService: summary always, full payload only on error
Co-authored-by: GitHub Copilot <noreply@github.com>